### PR TITLE
audit: move inventory bootstrap route

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -196,7 +196,7 @@ export function createApp() {
   app.use(express.json({ limit: getJsonBodyLimit() }))
 
   app.use('/api/bancos', createBancosRoutes({ getBankImportConfig, BankImportError }))
-  app.use('/api/inventario', createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError }))
+  app.use('/api/inventario', createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError, NetSuiteClient, fetchInventoryAdjustmentBootstrap, InventoryAdjustmentError }))
 
   app.use('/api', createBasicRoutes({
     overview,
@@ -210,18 +210,6 @@ export function createApp() {
     invoices,
     previewReconciliation,
   }))
-
-  app.get('/api/inventario/ajustes/bootstrap', async (_request, response) => {
-    try {
-      const client = NetSuiteClient.fromEnv()
-      response.json(await fetchInventoryAdjustmentBootstrap(client))
-    } catch (error) {
-      const status = error instanceof InventoryAdjustmentError ? error.status : 503
-      response.status(status).json({
-        error: error instanceof Error ? error.message : 'Unknown inventory adjustments bootstrap error.',
-      })
-    }
-  })
 
   app.get('/api/inventario/ajustes/items', async (request, response) => {
     try {

--- a/backend/src/routes/inventarioRoutes.ts
+++ b/backend/src/routes/inventarioRoutes.ts
@@ -1,7 +1,20 @@
 import { Router } from 'express'
 
-export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError }: any) {
+export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError, NetSuiteClient, fetchInventoryAdjustmentBootstrap, InventoryAdjustmentError }: any) {
   const router = Router()
+
+
+  router.get('/ajustes/bootstrap', async (_request, response) => {
+    try {
+      const client = NetSuiteClient.fromEnv()
+      response.json(await fetchInventoryAdjustmentBootstrap(client))
+    } catch (error) {
+      const status = error instanceof InventoryAdjustmentError ? error.status : 503
+      response.status(status).json({
+        error: error instanceof Error ? error.message : 'Unknown inventory adjustments bootstrap error.',
+      })
+    }
+  })
 
   router.post('/certificados/lookup', async (request, response) => {
     try {


### PR DESCRIPTION
TASK-006C: moves only GET /api/inventario/ajustes/bootstrap into inventario router. No behavior changes.