### PR TITLE
audit: move inventory lot summary route

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -211,18 +211,6 @@ export function createApp() {
     previewReconciliation,
   }))
 
-  app.post('/api/inventario/ajustes/lote-resumen', async (request, response) => {
-    try {
-      const client = NetSuiteClient.fromEnv()
-      response.json(await fetchInventoryLotSummary(client, request.body))
-    } catch (error) {
-      const status = error instanceof InventoryLotSummaryError ? error.status : 503
-      response.status(status).json({
-        error: error instanceof Error ? error.message : 'Unknown inventory lot summary error.',
-      })
-    }
-  })
-
   app.post('/api/inventario/ajustes/preview', async (request, response) => {
     try {
       const client = NetSuiteClient.fromEnv()

--- a/backend/src/routes/inventarioRoutes.ts
+++ b/backend/src/routes/inventarioRoutes.ts
@@ -4,12 +4,25 @@ function getErrorStatus(error: unknown) {
   return error instanceof Error && 'status' in error ? Number(error.status) : 503
 }
 
-export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError, NetSuiteClient, fetchInventoryAdjustmentBootstrap, fetchInventoryAdjustmentItemSnapshot, searchInventoryAdjustmentAccounts, searchInventoryAdjustmentItems, InventoryAdjustmentError }: any) {
+export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError, NetSuiteClient, fetchInventoryAdjustmentBootstrap, fetchInventoryAdjustmentItemSnapshot, fetchInventoryLotSummary, searchInventoryAdjustmentAccounts, searchInventoryAdjustmentItems, InventoryAdjustmentError, InventoryLotSummaryError }: any) {
   const router = Router()
 
 
 
 
+
+
+  router.post('/ajustes/lote-resumen', async (request, response) => {
+    try {
+      const client = NetSuiteClient.fromEnv()
+      response.json(await fetchInventoryLotSummary(client, request.body))
+    } catch (error) {
+      const status = getErrorStatus(error)
+      response.status(status).json({
+        error: error instanceof Error ? error.message : 'Unknown inventory lot summary error.',
+      })
+    }
+  })
 
   router.get('/ajustes/items/:itemId/snapshot', async (request, response) => {
     try {


### PR DESCRIPTION
TASK-006F2: moves only POST /api/inventario/ajustes/lote-resumen into inventario router. No behavior changes.