### PR TITLE
audit: move inventory execute route

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -211,18 +211,6 @@ export function createApp() {
     previewReconciliation,
   }))
 
-  app.post('/api/inventario/ajustes/execute', requireInternalApiKey, async (request, response) => {
-    try {
-      const client = NetSuiteClient.fromEnv()
-      response.json(await executeInventoryAdjustment(client, request.body))
-    } catch (error) {
-      const status = error instanceof InventoryAdjustmentError ? error.status : 503
-      response.status(status).json({
-        error: error instanceof Error ? error.message : 'Unknown inventory execution error.',
-      })
-    }
-  })
-
   app.post('/api/inventario/ajustes/reemplazar-lote', requireInternalApiKey, async (request, response) => {
     try {
       const client = NetSuiteClient.fromEnv()

--- a/backend/src/routes/inventarioRoutes.ts
+++ b/backend/src/routes/inventarioRoutes.ts
@@ -4,7 +4,7 @@ function getErrorStatus(error: unknown) {
   return error instanceof Error && 'status' in error ? Number(error.status) : 503
 }
 
-export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError, NetSuiteClient, fetchInventoryAdjustmentBootstrap, fetchInventoryAdjustmentItemSnapshot, fetchInventoryLotSummary, previewInventoryAdjustment, searchInventoryAdjustmentAccounts, searchInventoryAdjustmentItems, InventoryAdjustmentError, InventoryLotSummaryError }: any) {
+export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCertificateError, NetSuiteClient, executeInventoryAdjustment, fetchInventoryAdjustmentBootstrap, fetchInventoryAdjustmentItemSnapshot, fetchInventoryLotSummary, previewInventoryAdjustment, requireInternalApiKey, searchInventoryAdjustmentAccounts, searchInventoryAdjustmentItems, InventoryAdjustmentError, InventoryLotSummaryError }: any) {
   const router = Router()
 
 
@@ -12,6 +12,19 @@ export function createInventarioRoutes({ lookupInventoryCertificate, InventoryCe
 
 
 
+
+
+  router.post('/ajustes/execute', requireInternalApiKey, async (request, response) => {
+    try {
+      const client = NetSuiteClient.fromEnv()
+      response.json(await executeInventoryAdjustment(client, request.body))
+    } catch (error) {
+      const status = getErrorStatus(error)
+      response.status(status).json({
+        error: error instanceof Error ? error.message : 'Unknown inventory execution error.',
+      })
+    }
+  })
 
   router.post('/ajustes/preview', async (request, response) => {
     try {


### PR DESCRIPTION
TASK-006G1: moves only POST /api/inventario/ajustes/execute into inventario router, preserving requireInternalApiKey. No behavior changes.