### PR TITLE
refactor: remove try catch from bancos analyze handler

### DIFF
--- a/backend/src/routes/bancosRoutes.ts
+++ b/backend/src/routes/bancosRoutes.ts
@@ -32,15 +32,8 @@ export function createBancosRoutes(deps: BancosRouteDeps) {
   const router = Router()
 
   async function handleAnalyze(request: Request<unknown, unknown, BancosAnalyzeRequestBody>, response: Response) {
-    try {
-      const result: BancosAnalyzeResponseBody = await analyzeBankImport(request.body)
-      response.json(result)
-    } catch (error) {
-      const status = getErrorStatus(error)
-      response.status(status).json({
-        error: error instanceof Error ? error.message : 'Unknown bank import error.',
-      })
-    }
+    const result: BancosAnalyzeResponseBody = await analyzeBankImport(request.body)
+    response.json(result)
   }
 
   router.post('/analyze', validateBody(isBancosAnalyzeRequest, 'La solicitud de analisis bancario no es valida.'), handleAnalyze)


### PR DESCRIPTION
TASK-037 (part 2): removes try/catch from /analyze handler so errors flow to global middleware.