### PR TITLE
codex: file store reliability prototype

### DIFF
--- a/backend/src/bankEquivalenceStore.ts
+++ b/backend/src/bankEquivalenceStore.ts
@@ -28,12 +28,8 @@ type StoredBankEquivalenceOverrideFile = {
   items: StoredBankEquivalenceOverride[]
 }
 
-const OVERRIDE_STORE_PATH =
-  process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH?.trim() ||
-  path.join(process.env.LOCALAPPDATA || process.cwd(), 'netsuite-recon', 'bank-equivalence-overrides.json')
-
 export function loadBankEquivalenceOverrides() {
-  const parsed = readJsonFile<Partial<StoredBankEquivalenceOverrideFile>>(OVERRIDE_STORE_PATH, {
+  const parsed = readJsonFile<Partial<StoredBankEquivalenceOverrideFile>>(resolveOverrideStorePath(), {
     version: 2,
     items: [],
   })
@@ -80,9 +76,10 @@ function persistOverrides(items: StoredBankEquivalenceOverride[]) {
     version: 2,
     items,
   }
+  const storePath = resolveOverrideStorePath()
 
-  createBackupFile(OVERRIDE_STORE_PATH)
-  writeJsonFileAtomic(OVERRIDE_STORE_PATH, payload)
+  createBackupFile(storePath)
+  writeJsonFileAtomic(storePath, payload)
 }
 
 function isStoredOverride(value: unknown): value is StoredBankEquivalenceOverride {
@@ -150,4 +147,11 @@ function resolveLegacySourceProfileId(bankId: BankImportBankId, mappingSheetKey:
   }
 
   return 'payana_transacciones'
+}
+
+function resolveOverrideStorePath() {
+  return (
+    process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH?.trim() ||
+    path.join(process.env.LOCALAPPDATA || process.cwd(), 'netsuite-recon', 'bank-equivalence-overrides.json')
+  )
 }

--- a/backend/src/bankEquivalenceStore.ts
+++ b/backend/src/bankEquivalenceStore.ts
@@ -1,6 +1,10 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
+import {
+  createBackupFile,
+  readJsonFile,
+  writeJsonFileAtomic,
+} from './infrastructure/storage/fileStoreUtils.js'
 import type { BankImportBankId, BankImportMappingSheet } from './types.js'
 
 type MappingSheetKey = BankImportMappingSheet['key']
@@ -29,23 +33,18 @@ const OVERRIDE_STORE_PATH =
   path.join(process.env.LOCALAPPDATA || process.cwd(), 'netsuite-recon', 'bank-equivalence-overrides.json')
 
 export function loadBankEquivalenceOverrides() {
-  if (!fs.existsSync(OVERRIDE_STORE_PATH)) {
+  const parsed = readJsonFile<Partial<StoredBankEquivalenceOverrideFile>>(OVERRIDE_STORE_PATH, {
+    version: 2,
+    items: [],
+  })
+
+  if (!Array.isArray(parsed.items)) {
     return []
   }
 
-  try {
-    const raw = fs.readFileSync(OVERRIDE_STORE_PATH, 'utf8')
-    const parsed = JSON.parse(raw) as Partial<StoredBankEquivalenceOverrideFile>
-    if (!Array.isArray(parsed.items)) {
-      return []
-    }
-
-    return parsed.items
-      .map(normalizeStoredOverride)
-      .filter((item): item is StoredBankEquivalenceOverride => item !== null)
-  } catch {
-    return []
-  }
+  return parsed.items
+    .map(normalizeStoredOverride)
+    .filter((item): item is StoredBankEquivalenceOverride => item !== null)
 }
 
 export function upsertBankEquivalenceOverride(
@@ -77,15 +76,13 @@ export function upsertBankEquivalenceOverride(
 }
 
 function persistOverrides(items: StoredBankEquivalenceOverride[]) {
-  const directoryPath = path.dirname(OVERRIDE_STORE_PATH)
-  fs.mkdirSync(directoryPath, { recursive: true })
-
   const payload: StoredBankEquivalenceOverrideFile = {
     version: 2,
     items,
   }
 
-  fs.writeFileSync(OVERRIDE_STORE_PATH, JSON.stringify(payload, null, 2), 'utf8')
+  createBackupFile(OVERRIDE_STORE_PATH)
+  writeJsonFileAtomic(OVERRIDE_STORE_PATH, payload)
 }
 
 function isStoredOverride(value: unknown): value is StoredBankEquivalenceOverride {

--- a/backend/src/infrastructure/storage/fileStoreUtils.ts
+++ b/backend/src/infrastructure/storage/fileStoreUtils.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+type JsonFallback<T> = T | (() => T)
+
+export function readJsonFile<T>(filePath: string, fallback: JsonFallback<T>) {
+  if (!fs.existsSync(filePath)) {
+    return resolveFallback(fallback)
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/u, '')
+
+  try {
+    return JSON.parse(raw) as T
+  } catch (error) {
+    throw new Error(
+      `Failed to parse JSON file at ${filePath}: ${error instanceof Error ? error.message : 'Unknown parse error.'}`,
+    )
+  }
+}
+
+export function writeJsonFileAtomic(filePath: string, data: unknown) {
+  const directoryPath = path.dirname(filePath)
+  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`
+  const payload = safeJsonStringify(data)
+
+  fs.mkdirSync(directoryPath, { recursive: true })
+
+  try {
+    fs.writeFileSync(temporaryPath, payload, 'utf8')
+    fs.renameSync(temporaryPath, filePath)
+  } finally {
+    if (fs.existsSync(temporaryPath)) {
+      fs.rmSync(temporaryPath, { force: true })
+    }
+  }
+}
+
+export function createBackupFile(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    return null
+  }
+
+  const backupPath = `${filePath}.bak`
+  fs.copyFileSync(filePath, backupPath)
+  return backupPath
+}
+
+export function safeJsonStringify(data: unknown) {
+  const serialized = JSON.stringify(data, null, 2)
+
+  if (typeof serialized !== 'string') {
+    throw new Error('Unable to serialize JSON payload for file store persistence.')
+  }
+
+  return `${serialized}\n`
+}
+
+function resolveFallback<T>(fallback: JsonFallback<T>) {
+  return typeof fallback === 'function' ? (fallback as () => T)() : fallback
+}

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -175,6 +175,28 @@ Cobertura actual:
 - escritura por archivo temporal + rename
 - backup `.bak` optativo antes de sobrescribir
 
+## Limitaciones actuales del prototipo
+
+Este prototipo si mejora:
+
+- escritura atomica con archivo temporal + `rename`
+- backup previo al write
+- errores explicitos de parseo JSON
+- formato JSON estable con newline final
+
+Este prototipo no resuelve todavia:
+
+- `lost updates` por concurrencia `read-modify-write`
+- locking entre procesos
+- retencion historica de backups
+- recuperacion automatica de JSON corrupto
+- migracion de todos los stores
+
+En otras palabras:
+
+- reduce el riesgo de truncado y de overwrite sin respaldo inmediato
+- no elimina el problema de dos procesos leyendo el mismo estado viejo y escribiendo despues
+
 ### Tests agregados
 
 Archivo:
@@ -219,9 +241,18 @@ Alcance deliberadamente limitado:
 
 ## Estrategia de backup
 
-- crear backup solo antes de sobrescribir un archivo existente
-- usar sufijo con timestamp UTC o contador
-- rotar a un numero pequeno, por ejemplo 3 backups
+- decision de esta pasada: mantener un solo backup `.bak`
+- el `.bak` representa el snapshot inmediato anterior del archivo antes del ultimo write exitoso
+- no hay retencion historica ni timestamp en esta fase
+- se eligio esta opcion porque:
+  - reduce complejidad
+  - no cambia naming ni limpieza de archivos
+  - sigue siendo suficiente para validar el patron de backup previo a escritura
+
+Lo que implica:
+
+- cada nueva escritura puede sobrescribir el backup anterior
+- el `.bak` no sirve como historico largo ni auditoria de cambios
 
 ## Estrategia de locking
 
@@ -237,6 +268,54 @@ Orden recomendado:
 Motivo:
 
 - meter locks primero complica recovery y portabilidad Docker/NAS
+
+## Proxima fase recomendada: locking real
+
+Opciones razonables para la siguiente fase:
+
+### `proper-lockfile`
+
+Pros:
+
+- resuelve locking de archivos con una libreria conocida
+- reduce trabajo manual de retry/unlock
+- puede acelerar una migracion gradual store por store
+
+Contras:
+
+- agrega dependencia nueva
+- hay que validar bien su comportamiento en Docker/NAS y shares de red
+- requiere definir timeouts, stale locks y recovery
+
+### lockfile manual con apertura exclusiva
+
+Pros:
+
+- sin dependencia externa
+- control total del formato del lock y de la estrategia de expiracion
+
+Contras:
+
+- mas facil equivocarse en edge cases
+- mas trabajo de mantenimiento
+- recovery de locks huerfanos queda totalmente a cargo del repo
+
+### cola por proceso
+
+Pros:
+
+- simple dentro de un solo proceso Node
+- baja el riesgo de colisiones internas sin tocar filesystem locking aun
+
+Contras:
+
+- no protege contra multiples procesos o multiples contenedores
+- en Docker/NAS solo cubre una parte del problema real
+
+Recomendacion actual:
+
+- si el siguiente experimento sigue en el repo publico laboratorio, la mejor opcion para evaluar primero es `proper-lockfile`
+- si la compatibilidad Docker/NAS genera dudas, hacer un spike pequeno comparando `proper-lockfile` vs lock manual antes de migrar stores adicionales
 
 ## Validaciones y tests recomendados
 

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -140,10 +140,10 @@ Candidatos descartados para esta primera migracion:
 
 Contratos deseados:
 
-- `readJsonFileSafe(path, fallbackFactory, options)`
-- `parseJsonWithContext(raw, filePath)`
-- `createBackupPath(filePath, timestamp)`
-- `writeJsonFileAtomic(path, payload, options)`
+- `readJsonFile(path, fallback)`
+- `createBackupFile(path)`
+- `writeJsonFileAtomic(path, payload)`
+- `safeJsonStringify(payload)`
 
 Comportamiento recomendado:
 
@@ -151,6 +151,71 @@ Comportamiento recomendado:
 - `fs.renameSync(...)` o equivalente para swap atomico
 - backup opcional `*.bak`
 - errores con contexto del archivo y operacion
+
+## Estado del prototipo actual
+
+### Utilidades creadas
+
+Archivo:
+
+- `backend/src/infrastructure/storage/fileStoreUtils.ts`
+
+Funciones agregadas:
+
+- `readJsonFile(...)`
+- `writeJsonFileAtomic(...)`
+- `createBackupFile(...)`
+- `safeJsonStringify(...)`
+
+Cobertura actual:
+
+- lectura con fallback cuando el archivo no existe
+- parse explicito con contexto si el JSON esta corrupto
+- serializacion consistente con newline final
+- escritura por archivo temporal + rename
+- backup `.bak` optativo antes de sobrescribir
+
+### Tests agregados
+
+Archivo:
+
+- `tests/file-store-utils.test.mjs`
+
+Casos cubiertos:
+
+- `readJsonFile` devuelve fallback si el archivo no existe
+- `readJsonFile` lee JSON valido
+- `readJsonFile` falla explicitamente con JSON invalido
+- `writeJsonFileAtomic` crea JSON con newline final
+- `writeJsonFileAtomic` reemplaza contenido previo
+- `createBackupFile` crea `.bak` si existe archivo original
+- `createBackupFile` no falla si el archivo no existe
+
+### Store migrado en este prototipo
+
+- `backend/src/bankEquivalenceStore.ts`
+
+Cambio aplicado:
+
+- lectura manual sustituida por `readJsonFile(...)`
+- escritura directa sustituida por:
+  - `createBackupFile(...)`
+  - `writeJsonFileAtomic(...)`
+
+Motivo de seleccion:
+
+- pequeno
+- sin secretos
+- sin base64
+- sin dependencia de arranque base
+- estructura simple y buena para validar el patron
+
+Alcance deliberadamente limitado:
+
+- no cambia shape de datos
+- no cambia nombre de archivo
+- no introduce locking
+- no intenta migrar mas stores en esta rama
 
 ## Estrategia de backup
 
@@ -184,8 +249,61 @@ Motivo:
 - `git diff --check`
 - `python tools/check-text-encoding.py`
 
+## Stores pendientes prioritarios
+
+Siguientes candidatos razonables despues del piloto:
+
+1. `backend/src/bankBalanceValidationStore.ts`
+2. `backend/src/egresosConciliationStore.ts`
+3. `backend/src/netsuiteAccountStore.ts`
+
+Stores que conviene dejar para mas adelante:
+
+- `bankAnalysisRunStore.ts`
+- `bankWorkingFileStore.ts`
+- `bankIndividualPaymentStore.ts`
+- `satAnalysisWindows.ts`
+- `satDownloadHistoryStore.ts`
+- `netsuiteOAuth.ts`
+
+Motivo:
+
+- mayor impacto funcional
+- mayor volumen de datos
+- base64 o secretos
+- flujo mas sensible o cercano a integraciones
+
+## Riesgos restantes
+
+- no hay locking real todavia
+- los demas stores siguen con read/modify/write legacy
+- `createBackupFile(...)` usa un solo `.bak` y no tiene rotacion
+- no hay pruebas de concurrencia
+- la mayoria de loaders legacy siguen haciendo silent catch
+
+## Proxima fase recomendada
+
+1. decidir si conviene introducir locking real con `proper-lockfile` o alternativa minima
+2. agregar pruebas de concurrencia sobre temp dirs
+3. definir retencion de backups `.bak`
+4. migrar stores de riesgo bajo-medio de forma gradual
+5. definir estrategia de recuperacion para JSON corrupto
+6. evaluar si algun store necesita writer asincrono o cola dedicada
+
+## Validacion Docker aislada
+
+- No ejecutada en este entorno de Codex porque `docker` no esta instalado localmente.
+- Para validar el runtime aislado del laboratorio, usar:
+  - `docker compose -f deploy/test/docker-compose.public-test.yml -p shq-public-test up -d --build`
+  - `curl http://127.0.0.1:8090/api/health`
+  - `docker ps --format "table {{.Names}}\t{{.Ports}}\t{{.Status}}"`
+  - `docker logs --tail=80 shq-public-test`
+- Esa validacion debe confirmar que `shq-public-test` responde en `8090` sin tocar la instancia existente.
+
 ## Que no se implemento todavia
 
 - no se agrego `proper-lockfile`
-- no se migro ningun store
-- no se cambio comportamiento runtime de persistencia
+- no se migro todo el sistema
+- no se tocaron stores con secretos o base64 como piloto
+- no se agrego recuperacion automatica de JSON corrupto
+- no se tocaron deploys ni integraciones reales

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -4,25 +4,38 @@
 
 Reducir el riesgo de corrupcion o race condition en stores JSON sin migrarlos todos de golpe.
 
-## Stores encontrados
+## Inventario real de stores principales
 
-- `backend/src/bankAnalysisRunStore.ts`
-- `backend/src/bankBalanceValidationStore.ts`
-- `backend/src/bankEquivalenceStore.ts`
-- `backend/src/bankHistoricalRegistryStore.ts`
-- `backend/src/bankIndividualPaymentStore.ts`
-- `backend/src/bankRecognitionOverrideStore.ts`
-- `backend/src/bankWorkingFileStore.ts`
-- `backend/src/banxicoCepRecognitionStore.ts`
-- `backend/src/claveSatStore.ts`
-- `backend/src/egresosConciliationStore.ts`
-- `backend/src/kontempoStore.ts`
-- `backend/src/netsuiteAccountStore.ts`
-- `backend/src/netsuiteEntityStore.ts`
-- `backend/src/satDownloadHistoryStore.ts`
-- `backend/src/satIgnoredCfdiStore.ts`
-- `backend/src/satManualHomologationStore.ts`
-- `backend/src/satRetentionAccountStore.ts`
+| Archivo | Tipo de datos que maneja | Usa JSON | Lee y escribe | Riesgo de race condition | Riesgo de corrupcion parcial | Tiene silent catch | Candidato para primer prototipo | Riesgo de migrarlo |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `backend/src/bankAnalysisRunStore.ts` | corridas de analisis bancario | Si | Si | Alto | Alto | Si | No | Medio-alto |
+| `backend/src/bankBalanceValidationStore.ts` | saldos bancarios validados | Si | Si | Medio | Medio | Si | No | Medio |
+| `backend/src/bankEquivalenceStore.ts` | equivalencias manuales de contrapartes | Si | Si | Medio | Medio | Si | Si | Bajo-medio |
+| `backend/src/bankHistoricalRegistryStore.ts` | registros de cargas historicas bancarias | Si | Si | Alto | Alto | Si | No | Alto |
+| `backend/src/bankIndividualPaymentStore.ts` | archivos de pagos individuales con base64 | Si | Si | Medio | Alto | Si | No | Medio-alto |
+| `backend/src/bankRecognitionOverrideStore.ts` | overrides manuales de reconocimiento bancario | Si | Si | Alto | Alto | Si | No | Medio-alto |
+| `backend/src/bankWorkingFileStore.ts` | archivo bancario de trabajo con base64 | Si | Si | Alto | Alto | Si | No | Medio-alto |
+| `backend/src/banxicoCepRecognitionStore.ts` | reconocimientos manuales CEP | Si | Si | Medio-alto | Alto | Si | No | Medio-alto |
+| `backend/src/claveSatStore.ts` | snapshot de catalogo Clave SAT | Si | Si | Bajo-medio | Medio | Si | No | Medio |
+| `backend/src/egresosConciliationStore.ts` | conciliaciones locales de egresos | Si | Si | Medio | Medio | Si | No | Medio |
+| `backend/src/kontempoStore.ts` | homologaciones, recognitions e import runs de Kontempo | Si | Si | Alto | Alto | Si | No | Alto |
+| `backend/src/netsuiteAccountStore.ts` | cache de catalogo de cuentas NetSuite | Si | Si | Bajo-medio | Medio | Si | No | Medio |
+| `backend/src/netsuiteEntityStore.ts` | cache de catalogos de entidades NetSuite | Si | Si | Bajo-medio | Medio | Si | No | Medio |
+| `backend/src/satDownloadHistoryStore.ts` | historial de paquetes y CFDI SAT | Si | Si | Alto | Alto | Si | No | Alto |
+| `backend/src/satIgnoredCfdiStore.ts` | CFDI ignorados y motivos | Si | Si | Medio | Medio-alto | Si | No | Medio-alto |
+| `backend/src/satManualHomologationStore.ts` | homologaciones manuales SAT | Si | Si | Alto | Alto | Si | No | Alto |
+| `backend/src/satRetentionAccountStore.ts` | reglas de cuentas de retenciones SAT | Si | Si | Medio | Medio | Si | No | Medio |
+
+## Persistencias JSON auxiliares relacionadas
+
+Estas rutas no siguen el patron `*Store.ts`, pero si participan en el riesgo general de persistencia local y deben entrar en la hoja de ruta:
+
+| Archivo | Tipo de datos que maneja | Usa JSON | Lee y escribe | Riesgo principal | Silent catch | Notas |
+| --- | --- | --- | --- | --- | --- | --- |
+| `backend/src/netsuiteOAuth.ts` | sesion OAuth almacenada en disco | Si | Si | secreto en texto plano y write no atomico | No | no es candidato del prototipo por sensibilidad |
+| `backend/src/satAnalysisWindows.ts` | ventanas de analisis SAT | Si | Si | overwrites y estado de workflow | Si | mejor dejarlo para una fase posterior |
+| `backend/src/sat.ts` | manifiestos de cache SAT en disco | Si | Si | cache parcial o inconsistente | Si | mezcla cache binario y JSON |
+| `backend/src/inventoryLotReplacementRegistry.ts` | registry de reemplazos de lote | Si | Si | escritura async directa sin backup | Si | ligado a inventario, no ideal para piloto |
 
 ## Patron actual observado
 
@@ -39,6 +52,13 @@ Ejemplos representativos:
 - `backend/src/bankWorkingFileStore.ts`
 - cache/manifiesto en `backend/src/sat.ts`
 - token store en `backend/src/netsuiteOAuth.ts`
+
+Hallazgos comunes:
+
+- varios stores limpian BOM manualmente, pero no todos
+- la mayoria atrapa `JSON.parse(...)` con `catch { return [] }`
+- no hay atomicidad ni backups consistentes
+- no hay un helper compartido; cada store reimplementa lectura/escritura
 
 ## Riesgos actuales
 
@@ -87,17 +107,34 @@ Ejemplos representativos:
 
 ## Store piloto recomendado
 
-- `backend/src/bankAnalysisRunStore.ts`
+- candidato elegido para este prototipo: `backend/src/bankEquivalenceStore.ts`
 
 Motivos:
 
-- ya participa en analisis async de bancos
-- mezcla create/update/read de manera frecuente
-- una perdida o overwrite ahi pega a UX y trazabilidad
+- es pequeno y autocontenido
+- no guarda secretos ni archivos base64
+- no participa en el arranque base ni en `api/health`
+- su estructura es simple:
+  - `version`
+  - `items`
+- el flujo de `load/upsert/persist` es directo y facil de probar
+- si una corrupcion de JSON aparece, el impacto de negocio es menor que en SAT, OAuth, working files o analysis runs
 
-Segundo candidato:
+Candidatos de segunda linea:
 
-- `backend/src/bankWorkingFileStore.ts`
+- `backend/src/bankBalanceValidationStore.ts`
+- `backend/src/egresosConciliationStore.ts`
+
+Candidatos descartados para esta primera migracion:
+
+- `bankWorkingFileStore.ts`
+  - guarda base64 de archivos bancarios
+- `bankIndividualPaymentStore.ts`
+  - guarda base64 y volumen de datos mayor
+- `bankAnalysisRunStore.ts`
+  - mas critico para trazabilidad de analisis
+- `netsuiteOAuth.ts`
+  - maneja tokens/sesion y requiere un diseno de seguridad separado
 
 ## Diseno sugerido de helper base
 

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -213,6 +213,19 @@ Casos cubiertos:
 - `createBackupFile` crea `.bak` si existe archivo original
 - `createBackupFile` no falla si el archivo no existe
 
+### Tests del store migrado
+
+Archivo:
+
+- `tests/bank-equivalence-store.test.mjs`
+
+Casos cubiertos:
+
+- `loadBankEquivalenceOverrides` devuelve `[]` si no existe archivo
+- `upsertBankEquivalenceOverride` crea archivo `version: 2` con timestamps
+- un segundo `upsert` del mismo item no duplica registros y genera `.bak`
+- un JSON corrupto lanza error explicito con el path del archivo
+
 ### Store migrado en este prototipo
 
 - `backend/src/bankEquivalenceStore.ts`
@@ -223,6 +236,7 @@ Cambio aplicado:
 - escritura directa sustituida por:
   - `createBackupFile(...)`
   - `writeJsonFileAtomic(...)`
+- resolucion del path movida a `resolveOverrideStorePath()` por llamada
 
 Motivo de seleccion:
 
@@ -238,6 +252,13 @@ Alcance deliberadamente limitado:
 - no cambia nombre de archivo
 - no introduce locking
 - no intenta migrar mas stores en esta rama
+
+## Diseno actual del path del store
+
+- `bankEquivalenceStore` ya no fija el path del archivo solo al cargar el modulo
+- el path se resuelve en cada `load` y `persist` con `resolveOverrideStorePath()`
+- esto mantiene el comportamiento por defecto, pero hace viable probar el store con `BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH` temporal
+- no se cambio el nombre del archivo real ni su ubicacion por defecto
 
 ## Estrategia de backup
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev:backend": "npm --prefix backend run dev",
     "prebuild": "npm --prefix backend run build",
     "build": "npm --prefix frontend run build",
-    "test": "node --test tests/backend-safety.test.mjs",
+    "test": "node --test tests/*.test.mjs",
     "prelint": "npm --prefix backend run lint",
     "lint": "npm --prefix frontend run lint"
   }

--- a/tests/bank-equivalence-store.test.mjs
+++ b/tests/bank-equivalence-store.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  loadBankEquivalenceOverrides,
+  upsertBankEquivalenceOverride,
+} from '../backend/dist/bankEquivalenceStore.js'
+
+function withTempDirectory(callback) {
+  const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bank-equivalence-store-'))
+
+  try {
+    callback(tempDirectoryPath)
+  } finally {
+    fs.rmSync(tempDirectoryPath, { recursive: true, force: true })
+  }
+}
+
+function withEquivalenceStorePath(filePath, callback) {
+  const previousValue = process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH
+
+  process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH = filePath
+
+  try {
+    callback()
+  } finally {
+    if (typeof previousValue === 'string') {
+      process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH = previousValue
+    } else {
+      delete process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH
+    }
+  }
+}
+
+function createOverrideInput(overrides = {}) {
+  return {
+    bankId: 'bbva',
+    sourceProfileId: 'bbva_pdf',
+    mappingSheetKey: 'customers',
+    counterpartyName: 'Acme SA de CV',
+    normalizedCounterpartyName: 'ACME SA DE CV',
+    compactCounterpartyName: 'ACMESADECV',
+    selectedBankName: 'ACME SA',
+    netsuiteName: 'ACME CUSTOMER',
+    creditAccount: '1150',
+    ...overrides,
+  }
+}
+
+test('loadBankEquivalenceOverrides returns an empty array when the file does not exist', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+
+    withEquivalenceStorePath(filePath, () => {
+      assert.deepEqual(loadBankEquivalenceOverrides(), [])
+    })
+  })
+})
+
+test('upsertBankEquivalenceOverride creates a version 2 file with one item', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+
+    withEquivalenceStorePath(filePath, () => {
+      const stored = upsertBankEquivalenceOverride(createOverrideInput())
+      const rawFile = fs.readFileSync(filePath, 'utf8')
+      const parsed = JSON.parse(rawFile)
+
+      assert.equal(parsed.version, 2)
+      assert.equal(parsed.items.length, 1)
+      assert.equal(parsed.items[0].bankId, 'bbva')
+      assert.equal(typeof parsed.items[0].createdAtUtc, 'string')
+      assert.equal(typeof parsed.items[0].updatedAtUtc, 'string')
+      assert.equal(stored.createdAtUtc, parsed.items[0].createdAtUtc)
+      assert.equal(stored.updatedAtUtc, parsed.items[0].updatedAtUtc)
+    })
+  })
+})
+
+test('upsertBankEquivalenceOverride updates the same item without duplicating it and creates a backup', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+
+    withEquivalenceStorePath(filePath, () => {
+      const first = upsertBankEquivalenceOverride(createOverrideInput())
+      const second = upsertBankEquivalenceOverride(
+        createOverrideInput({
+          selectedBankName: 'ACME SA UPDATED',
+          netsuiteName: 'ACME CUSTOMER UPDATED',
+        }),
+      )
+
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      const backup = JSON.parse(fs.readFileSync(`${filePath}.bak`, 'utf8'))
+
+      assert.equal(parsed.items.length, 1)
+      assert.equal(parsed.items[0].selectedBankName, 'ACME SA UPDATED')
+      assert.equal(parsed.items[0].netsuiteName, 'ACME CUSTOMER UPDATED')
+      assert.equal(second.createdAtUtc, first.createdAtUtc)
+      assert.equal(second.updatedAtUtc >= first.updatedAtUtc, true)
+      assert.equal(fs.existsSync(`${filePath}.bak`), true)
+      assert.equal(backup.items.length, 1)
+      assert.equal(backup.items[0].selectedBankName, 'ACME SA')
+    })
+  })
+})
+
+test('loadBankEquivalenceOverrides throws an explicit error when the JSON file is corrupt', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+    fs.writeFileSync(filePath, '{ invalid json }\n', 'utf8')
+
+    withEquivalenceStorePath(filePath, () => {
+      assert.throws(
+        () => loadBankEquivalenceOverrides(),
+        (error) =>
+          error instanceof Error &&
+          error.message.includes('Failed to parse JSON file at') &&
+          error.message.includes(filePath),
+      )
+    })
+  })
+})

--- a/tests/file-store-utils.test.mjs
+++ b/tests/file-store-utils.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  createBackupFile,
+  readJsonFile,
+  safeJsonStringify,
+  writeJsonFileAtomic,
+} from '../backend/dist/infrastructure/storage/fileStoreUtils.js'
+
+function withTempDirectory(callback) {
+  const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'file-store-utils-'))
+
+  try {
+    callback(tempDirectoryPath)
+  } finally {
+    fs.rmSync(tempDirectoryPath, { recursive: true, force: true })
+  }
+}
+
+test('readJsonFile returns the fallback when the file does not exist', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'missing.json')
+
+    assert.deepEqual(readJsonFile(filePath, { items: [] }), { items: [] })
+  })
+})
+
+test('readJsonFile reads valid JSON content', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'valid.json')
+    fs.writeFileSync(filePath, '{\n  "value": 42\n}\n', 'utf8')
+
+    assert.deepEqual(readJsonFile(filePath, { value: 0 }), { value: 42 })
+  })
+})
+
+test('readJsonFile fails explicitly when the JSON is invalid', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'invalid.json')
+    fs.writeFileSync(filePath, '{ invalid json }\n', 'utf8')
+
+    assert.throws(
+      () => readJsonFile(filePath, { value: 0 }),
+      (error) =>
+        error instanceof Error &&
+        error.message.includes('Failed to parse JSON file at') &&
+        error.message.includes(filePath),
+    )
+  })
+})
+
+test('writeJsonFileAtomic creates a JSON file with a final newline', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'payload.json')
+
+    writeJsonFileAtomic(filePath, { ok: true })
+
+    const written = fs.readFileSync(filePath, 'utf8')
+    assert.equal(written, '{\n  "ok": true\n}\n')
+    assert.equal(written.endsWith('\n'), true)
+  })
+})
+
+test('writeJsonFileAtomic replaces existing content', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'payload.json')
+    fs.writeFileSync(filePath, '{\n  "old": true\n}\n', 'utf8')
+
+    writeJsonFileAtomic(filePath, { next: 'value' })
+
+    assert.deepEqual(JSON.parse(fs.readFileSync(filePath, 'utf8')), { next: 'value' })
+  })
+})
+
+test('createBackupFile creates a .bak copy when the original file exists', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'payload.json')
+    fs.writeFileSync(filePath, safeJsonStringify({ source: 'original' }), 'utf8')
+
+    const backupPath = createBackupFile(filePath)
+
+    assert.equal(backupPath, `${filePath}.bak`)
+    assert.equal(fs.existsSync(`${filePath}.bak`), true)
+    assert.deepEqual(JSON.parse(fs.readFileSync(`${filePath}.bak`, 'utf8')), { source: 'original' })
+  })
+})
+
+test('createBackupFile does not fail when the original file does not exist', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'missing.json')
+
+    assert.equal(createBackupFile(filePath), null)
+    assert.equal(fs.existsSync(`${filePath}.bak`), false)
+  })
+})


### PR DESCRIPTION
## Objetivo

Crear base no invasiva para mejorar confiabilidad de JSON file stores sin migrar todo el sistema.

## Cambios incluidos

- inventario real de stores JSON y persistencias auxiliares relacionadas
- utilidades base `fileStoreUtils` para lectura segura, backup y escritura atomica
- tests para `fileStoreUtils` con `node --test`
- migracion inicial de `bankEquivalenceStore` al patron atomico con backup `.bak`
- resolucion del path del store por llamada para habilitar tests aislados
- tests del store migrado y documentacion de limites, backup y siguiente fase de locking

## Validaciones

- `npm --prefix backend run build`: OK
- `npm --prefix frontend run build`: OK
- `npm test`: OK
- `git diff --check`: OK
- `python tools/check-text-encoding.py`: OK
- Docker isolated test: Not run

## Riesgos restantes

- no hay locking real todavia
- solo un store fue migrado
- siguen siendo posibles `lost updates` bajo concurrencia `read-modify-write`
- el backup actual usa un solo `.bak` sin retencion historica

## Que NO se toco

- `main`
- repo privado
- produccion
- secretos
- integraciones reales
- todos los stores
- deploy actual

## Recomendacion

Mantener este PR como draft y usarlo como prototipo revisable antes de decidir una fase posterior de locking real y migracion gradual por store.
