### PR TITLE
codex: file store locking prototype

### DIFF
--- a/backend/src/bankEquivalenceStore.ts
+++ b/backend/src/bankEquivalenceStore.ts
@@ -5,6 +5,7 @@ import {
   readJsonFile,
   writeJsonFileAtomic,
 } from './infrastructure/storage/fileStoreUtils.js'
+import { withFileLock } from './infrastructure/storage/fileStoreLock.js'
 import type { BankImportBankId, BankImportMappingSheet } from './types.js'
 
 type MappingSheetKey = BankImportMappingSheet['key']
@@ -29,7 +30,43 @@ type StoredBankEquivalenceOverrideFile = {
 }
 
 export function loadBankEquivalenceOverrides() {
-  const parsed = readJsonFile<Partial<StoredBankEquivalenceOverrideFile>>(resolveOverrideStorePath(), {
+  return loadOverridesFromPath(resolveOverrideStorePath())
+}
+
+export function upsertBankEquivalenceOverride(
+  input: Omit<StoredBankEquivalenceOverride, 'createdAtUtc' | 'updatedAtUtc'>,
+) {
+  const storePath = resolveOverrideStorePath()
+
+  return withFileLock(storePath, () => {
+    const currentItems = loadOverridesFromPath(storePath)
+    const now = new Date().toISOString()
+    const existingIndex = currentItems.findIndex(
+      (item) =>
+        item.bankId === input.bankId &&
+        item.sourceProfileId === input.sourceProfileId &&
+        item.mappingSheetKey === input.mappingSheetKey &&
+        item.normalizedCounterpartyName === input.normalizedCounterpartyName,
+    )
+
+    const nextItem: StoredBankEquivalenceOverride = {
+      ...input,
+      createdAtUtc: existingIndex >= 0 ? currentItems[existingIndex].createdAtUtc : now,
+      updatedAtUtc: now,
+    }
+
+    const nextItems =
+      existingIndex >= 0
+        ? currentItems.map((item, index) => (index === existingIndex ? nextItem : item))
+        : [...currentItems, nextItem]
+
+    persistOverrides(storePath, nextItems)
+    return nextItem
+  })
+}
+
+function loadOverridesFromPath(storePath: string) {
+  const parsed = readJsonFile<Partial<StoredBankEquivalenceOverrideFile>>(storePath, {
     version: 2,
     items: [],
   })
@@ -43,40 +80,11 @@ export function loadBankEquivalenceOverrides() {
     .filter((item): item is StoredBankEquivalenceOverride => item !== null)
 }
 
-export function upsertBankEquivalenceOverride(
-  input: Omit<StoredBankEquivalenceOverride, 'createdAtUtc' | 'updatedAtUtc'>,
-) {
-  const currentItems = loadBankEquivalenceOverrides()
-  const now = new Date().toISOString()
-  const existingIndex = currentItems.findIndex(
-    (item) =>
-      item.bankId === input.bankId &&
-      item.sourceProfileId === input.sourceProfileId &&
-      item.mappingSheetKey === input.mappingSheetKey &&
-      item.normalizedCounterpartyName === input.normalizedCounterpartyName,
-  )
-
-  const nextItem: StoredBankEquivalenceOverride = {
-    ...input,
-    createdAtUtc: existingIndex >= 0 ? currentItems[existingIndex].createdAtUtc : now,
-    updatedAtUtc: now,
-  }
-
-  const nextItems =
-    existingIndex >= 0
-      ? currentItems.map((item, index) => (index === existingIndex ? nextItem : item))
-      : [...currentItems, nextItem]
-
-  persistOverrides(nextItems)
-  return nextItem
-}
-
-function persistOverrides(items: StoredBankEquivalenceOverride[]) {
+function persistOverrides(storePath: string, items: StoredBankEquivalenceOverride[]) {
   const payload: StoredBankEquivalenceOverrideFile = {
     version: 2,
     items,
   }
-  const storePath = resolveOverrideStorePath()
 
   createBackupFile(storePath)
   writeJsonFileAtomic(storePath, payload)

--- a/backend/src/infrastructure/storage/fileStoreLock.ts
+++ b/backend/src/infrastructure/storage/fileStoreLock.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_RETRY_DELAY_MS = 25
+const DEFAULT_TIMEOUT_MS = 2_000
+const DEFAULT_STALE_AFTER_MS = 30_000
+
+export type FileLockOptions = {
+  retryDelayMs?: number
+  timeoutMs?: number
+  staleAfterMs?: number
+  now?: () => number
+  sleep?: (milliseconds: number) => void
+}
+
+export function withFileLock<T>(filePath: string, callback: () => T, options: FileLockOptions = {}) {
+  const lockPath = resolveLockPath(filePath)
+  const retryDelayMs = normalizePositiveNumber(options.retryDelayMs, DEFAULT_RETRY_DELAY_MS)
+  const timeoutMs = normalizePositiveNumber(options.timeoutMs, DEFAULT_TIMEOUT_MS)
+  const staleAfterMs = normalizePositiveNumber(options.staleAfterMs, DEFAULT_STALE_AFTER_MS)
+  const now = options.now ?? Date.now
+  const sleep = options.sleep ?? sleepSync
+  const deadline = now() + timeoutMs
+
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true })
+
+  while (true) {
+    if (tryAcquireLock(lockPath, filePath, now)) {
+      return runWithLock(lockPath, callback)
+    }
+
+    if (removeStaleLockIfPresent(lockPath, staleAfterMs, now)) {
+      continue
+    }
+
+    if (now() >= deadline) {
+      throw new Error(`Timed out acquiring file lock for ${filePath} after ${timeoutMs}ms.`)
+    }
+
+    sleep(retryDelayMs)
+  }
+}
+
+export function resolveLockPath(filePath: string) {
+  return `${filePath}.lock`
+}
+
+function runWithLock<T>(lockPath: string, callback: () => T) {
+  let callbackResult: T | undefined
+  let callbackError: unknown
+  let didCallbackThrow = false
+
+  try {
+    callbackResult = callback()
+  } catch (error) {
+    didCallbackThrow = true
+    callbackError = error
+  }
+
+  try {
+    releaseLock(lockPath)
+  } catch (error) {
+    if (didCallbackThrow) {
+      throw callbackError
+    }
+
+    throw error
+  }
+
+  if (didCallbackThrow) {
+    throw callbackError
+  }
+
+  return callbackResult as T
+}
+
+function tryAcquireLock(lockPath: string, filePath: string, now: () => number) {
+  let descriptor: number | null = null
+
+  try {
+    descriptor = fs.openSync(lockPath, 'wx')
+    const metadata = `${JSON.stringify({
+      pid: process.pid,
+      filePath,
+      createdAtUtc: new Date(now()).toISOString(),
+    })}\n`
+
+    fs.writeFileSync(descriptor, metadata, 'utf8')
+    return true
+  } catch (error) {
+    if (isNodeError(error, 'EEXIST')) {
+      return false
+    }
+
+    throw new Error(
+      `Failed to acquire file lock at ${lockPath}: ${error instanceof Error ? error.message : 'Unknown lock error.'}`,
+    )
+  } finally {
+    if (descriptor !== null) {
+      fs.closeSync(descriptor)
+    }
+  }
+}
+
+function releaseLock(lockPath: string) {
+  try {
+    fs.rmSync(lockPath, { force: true })
+  } catch (error) {
+    throw new Error(
+      `Failed to release file lock at ${lockPath}: ${error instanceof Error ? error.message : 'Unknown release error.'}`,
+    )
+  }
+}
+
+function removeStaleLockIfPresent(lockPath: string, staleAfterMs: number, now: () => number) {
+  try {
+    const stats = fs.statSync(lockPath)
+    if (now() - stats.mtimeMs < staleAfterMs) {
+      return false
+    }
+
+    fs.rmSync(lockPath, { force: true })
+    return true
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) {
+      return false
+    }
+
+    throw new Error(
+      `Failed to inspect file lock at ${lockPath}: ${error instanceof Error ? error.message : 'Unknown stat error.'}`,
+    )
+  }
+}
+
+function sleepSync(milliseconds: number) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds)
+}
+
+function normalizePositiveNumber(value: number | undefined, fallback: number) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return fallback
+  }
+
+  return Math.floor(value)
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === 'object' && 'code' in error && (error as { code?: unknown }).code === code)
+}

--- a/backend/src/infrastructure/storage/fileStoreLock.ts
+++ b/backend/src/infrastructure/storage/fileStoreLock.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -13,6 +14,25 @@ export type FileLockOptions = {
   sleep?: (milliseconds: number) => void
 }
 
+type FileLockMetadata = {
+  lockId: string
+  pid: number
+  filePath: string
+  createdAtUtc: string
+}
+
+type FileLockHandle = {
+  lockId: string
+  lockPath: string
+}
+
+type FileLockSnapshot = {
+  metadata: FileLockMetadata | null
+  raw: string
+  size: number
+  mtimeMs: number
+}
+
 export function withFileLock<T>(filePath: string, callback: () => T, options: FileLockOptions = {}) {
   const lockPath = resolveLockPath(filePath)
   const retryDelayMs = normalizePositiveNumber(options.retryDelayMs, DEFAULT_RETRY_DELAY_MS)
@@ -25,8 +45,9 @@ export function withFileLock<T>(filePath: string, callback: () => T, options: Fi
   fs.mkdirSync(path.dirname(lockPath), { recursive: true })
 
   while (true) {
-    if (tryAcquireLock(lockPath, filePath, now)) {
-      return runWithLock(lockPath, callback)
+    const lockHandle = tryAcquireLock(lockPath, filePath, now)
+    if (lockHandle) {
+      return runWithLock(lockHandle, callback)
     }
 
     if (removeStaleLockIfPresent(lockPath, staleAfterMs, now)) {
@@ -45,7 +66,7 @@ export function resolveLockPath(filePath: string) {
   return `${filePath}.lock`
 }
 
-function runWithLock<T>(lockPath: string, callback: () => T) {
+function runWithLock<T>(lockHandle: FileLockHandle, callback: () => T) {
   let callbackResult: T | undefined
   let callbackError: unknown
   let didCallbackThrow = false
@@ -58,7 +79,7 @@ function runWithLock<T>(lockPath: string, callback: () => T) {
   }
 
   try {
-    releaseLock(lockPath)
+    releaseLock(lockHandle)
   } catch (error) {
     if (didCallbackThrow) {
       throw callbackError
@@ -76,20 +97,25 @@ function runWithLock<T>(lockPath: string, callback: () => T) {
 
 function tryAcquireLock(lockPath: string, filePath: string, now: () => number) {
   let descriptor: number | null = null
+  const metadata: FileLockMetadata = {
+    lockId: randomUUID(),
+    pid: process.pid,
+    filePath,
+    createdAtUtc: new Date(now()).toISOString(),
+  }
 
   try {
     descriptor = fs.openSync(lockPath, 'wx')
-    const metadata = `${JSON.stringify({
-      pid: process.pid,
-      filePath,
-      createdAtUtc: new Date(now()).toISOString(),
-    })}\n`
+    const serializedMetadata = `${JSON.stringify(metadata)}\n`
 
-    fs.writeFileSync(descriptor, metadata, 'utf8')
-    return true
+    fs.writeFileSync(descriptor, serializedMetadata, 'utf8')
+    return {
+      lockId: metadata.lockId,
+      lockPath,
+    }
   } catch (error) {
     if (isNodeError(error, 'EEXIST')) {
-      return false
+      return null
     }
 
     throw new Error(
@@ -102,24 +128,54 @@ function tryAcquireLock(lockPath: string, filePath: string, now: () => number) {
   }
 }
 
-function releaseLock(lockPath: string) {
+function releaseLock(lockHandle: FileLockHandle) {
+  const snapshot = readLockSnapshot(lockHandle.lockPath)
+  if (!snapshot) {
+    throw new Error(`Failed to release file lock at ${lockHandle.lockPath}: lock file is missing.`)
+  }
+
+  if (!snapshot.metadata) {
+    throw new Error(
+      `Failed to release file lock at ${lockHandle.lockPath}: lock metadata is unreadable, ownership cannot be verified.`,
+    )
+  }
+
+  if (snapshot.metadata.lockId !== lockHandle.lockId) {
+    throw new Error(
+      `Failed to release file lock at ${lockHandle.lockPath}: ownership mismatch for lockId ${lockHandle.lockId}.`,
+    )
+  }
+
   try {
-    fs.rmSync(lockPath, { force: true })
+    fs.rmSync(lockHandle.lockPath)
   } catch (error) {
     throw new Error(
-      `Failed to release file lock at ${lockPath}: ${error instanceof Error ? error.message : 'Unknown release error.'}`,
+      `Failed to release file lock at ${lockHandle.lockPath}: ${error instanceof Error ? error.message : 'Unknown release error.'}`,
     )
   }
 }
 
 function removeStaleLockIfPresent(lockPath: string, staleAfterMs: number, now: () => number) {
-  try {
-    const stats = fs.statSync(lockPath)
-    if (now() - stats.mtimeMs < staleAfterMs) {
-      return false
-    }
+  const firstSnapshot = readLockSnapshot(lockPath)
+  if (!firstSnapshot) {
+    return false
+  }
 
-    fs.rmSync(lockPath, { force: true })
+  if (now() - firstSnapshot.mtimeMs < staleAfterMs) {
+    return false
+  }
+
+  const secondSnapshot = readLockSnapshot(lockPath)
+  if (!secondSnapshot) {
+    return false
+  }
+
+  if (!isSameSnapshot(firstSnapshot, secondSnapshot)) {
+    return false
+  }
+
+  try {
+    fs.rmSync(lockPath)
     return true
   } catch (error) {
     if (isNodeError(error, 'ENOENT')) {
@@ -146,4 +202,56 @@ function normalizePositiveNumber(value: number | undefined, fallback: number) {
 
 function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
   return Boolean(error && typeof error === 'object' && 'code' in error && (error as { code?: unknown }).code === code)
+}
+
+function readLockSnapshot(lockPath: string): FileLockSnapshot | null {
+  try {
+    const stats = fs.statSync(lockPath)
+    const raw = fs.readFileSync(lockPath, 'utf8')
+    return {
+      metadata: parseLockMetadata(raw),
+      raw,
+      size: stats.size,
+      mtimeMs: stats.mtimeMs,
+    }
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) {
+      return null
+    }
+
+    throw new Error(
+      `Failed to inspect file lock at ${lockPath}: ${error instanceof Error ? error.message : 'Unknown stat error.'}`,
+    )
+  }
+}
+
+function parseLockMetadata(raw: string): FileLockMetadata | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<FileLockMetadata>
+    if (
+      typeof parsed.lockId !== 'string' ||
+      typeof parsed.pid !== 'number' ||
+      typeof parsed.filePath !== 'string' ||
+      typeof parsed.createdAtUtc !== 'string'
+    ) {
+      return null
+    }
+
+    return {
+      lockId: parsed.lockId,
+      pid: parsed.pid,
+      filePath: parsed.filePath,
+      createdAtUtc: parsed.createdAtUtc,
+    }
+  } catch {
+    return null
+  }
+}
+
+function isSameSnapshot(firstSnapshot: FileLockSnapshot, secondSnapshot: FileLockSnapshot) {
+  return (
+    firstSnapshot.raw === secondSnapshot.raw &&
+    firstSnapshot.size === secondSnapshot.size &&
+    firstSnapshot.mtimeMs === secondSnapshot.mtimeMs
+  )
 }

--- a/docs/codex/file-store-locking-design.md
+++ b/docs/codex/file-store-locking-design.md
@@ -1,0 +1,128 @@
+# File Store Locking Design
+
+## Objetivo
+
+Agregar un primer mecanismo de locking para reducir `lost updates` en ciclos `read-modify-write` sobre stores JSON locales.
+
+## Problema que si resuelve
+
+- dos escritores concurrentes pueden leer el mismo estado previo y sobrescribir cambios del otro
+- un lock alrededor de todo el ciclo `read-modify-write` serializa escrituras sobre el mismo archivo
+
+## Problema que no resuelve
+
+- corrupcion previa del JSON antes de adquirir el lock
+- merge semantico de cambios incompatibles
+- coordinacion distribuida fuera del filesystem local compartido, si existiera
+- conflictos logicos entre operaciones validas que necesiten resolucion de dominio
+
+## Opciones evaluadas
+
+### `proper-lockfile`
+
+Pros:
+
+- libreria conocida para locks de archivos
+- incluye manejo de stale locks y reintentos
+- podria simplificar una migracion gradual futura
+
+Contras:
+
+- agrega dependencia nueva al backend
+- necesita validacion especifica en Docker y NAS
+- introduce mas superficie de configuracion para un primer experimento
+
+### lockfile manual con `fs.openSync('wx')`
+
+Pros:
+
+- sin dependencias nuevas
+- facil de auditar
+- suficiente para un prototipo pequeno y localizado
+
+Contras:
+
+- stale locks y timeouts quedan a cargo del repo
+- hay que documentar bien sus limites
+- no cubre escenarios distribuidos complejos
+
+### cola en memoria por proceso
+
+Pros:
+
+- implementacion simple
+- baja contencion dentro de un solo proceso Node
+
+Contras:
+
+- no protege entre procesos ni contenedores
+- no ataca el riesgo real del laboratorio NAS/Docker
+
+### mutex async local
+
+Pros:
+
+- ergonomia comoda si toda la capa fuera async
+
+Contras:
+
+- no encaja bien con stores actuales, que son sincronos
+- solo protege dentro del proceso actual
+
+### no locking y solo atomic write
+
+Pros:
+
+- menor complejidad
+- ya reduce truncados y escrituras parciales
+
+Contras:
+
+- no evita `lost updates`
+- deja abierto el riesgo principal identificado para stores JSON
+
+## Recomendacion para este prototipo
+
+- preferir un lockfile manual en filesystem local con `fs.openSync('wx')`
+- mantenerlo pequeno, sin dependencia externa, para validar comportamiento y tests
+- reservar `proper-lockfile` para una fase posterior solo si este prototipo resulta insuficiente o fragil
+
+## Recomendacion para NAS / Docker
+
+- este prototipo asume un filesystem local o montado donde `open(..., 'wx')` y `rename` mantengan semantica consistente
+- para el laboratorio actual, eso es suficiente como primera aproximacion
+- antes de cualquier uso serio fuera del laboratorio, conviene verificar comportamiento sobre el montaje real del NAS y revisar si aparecen locks stale o errores de permisos
+
+## Riesgos del enfoque
+
+- deadlocks practicos si un lock queda stale y el cleanup no ocurre
+- falsos positivos de stale lock si el timeout es demasiado agresivo
+- diferencias de permisos o semantica entre Windows y Linux
+- cleanup en crash abrupto del proceso
+- posibilidad de que un share remoto no respete exactamente la semantica esperada
+
+## Mitigaciones propuestas
+
+- metadata minima dentro del `.lock` con `pid` y timestamp
+- timeout corto de espera para fallar de forma explicita
+- remocion de stale locks por edad configurable
+- tests en temp dirs para asegurar cleanup y exclusividad basica
+
+## Primer store candidato
+
+- `backend/src/bankEquivalenceStore.ts`
+
+Motivos:
+
+- ya usa `readJsonFile`, `createBackupFile` y `writeJsonFileAtomic`
+- no maneja secretos ni base64
+- su `upsert` cubre un caso real de `read-modify-write`
+- el impacto funcional es menor que en stores de SAT, OAuth o analysis runs
+
+## Alcance deliberadamente limitado
+
+- no migrar todos los stores
+- no agregar locking global
+- no resolver merges semanticos
+- no tocar produccion ni integraciones reales
+- no introducir colas distribuidas ni coordinacion entre servicios

--- a/docs/codex/file-store-locking-design.md
+++ b/docs/codex/file-store-locking-design.md
@@ -103,10 +103,42 @@ Contras:
 
 ## Mitigaciones propuestas
 
-- metadata minima dentro del `.lock` con `pid` y timestamp
+- metadata minima dentro del `.lock` con `lockId`, `pid`, `filePath` y timestamp
 - timeout corto de espera para fallar de forma explicita
-- remocion de stale locks por edad configurable
+- validacion de ownership antes de liberar el lock
+- remocion de stale locks por edad configurable con doble lectura antes del delete
 - tests en temp dirs para asegurar cleanup y exclusividad basica
+
+## Implementacion actual del prototipo
+
+- `withFileLock(...)` sigue siendo sincrono para encajar con stores sincronos existentes
+- el helper crea `${filePath}.lock`
+- la adquisicion usa `fs.openSync(lockPath, 'wx')`
+- el metadata del lock incluye `lockId`, `pid`, `filePath` y `createdAtUtc`
+- `releaseLock(...)` relee el metadata y solo borra el lock si el `lockId` coincide
+- el cleanup de stale lock relee el archivo antes del delete para bajar el riesgo de borrar un lock recien reemplazado
+
+## Limites del ownership actual
+
+- el ownership check evita borrar un lock ajeno si el archivo ya fue reemplazado antes de `release`
+- no garantiza un compare-and-delete atomico a nivel filesystem
+- si otro proceso reemplazara el lock exactamente entre la verificacion y el `rmSync`, el prototipo no puede impedirlo con este enfoque manual
+- ese limite sigue siendo aceptable solo para laboratorio y debe revisarse antes de pensar en un uso mas amplio
+
+## Limites del stale cleanup actual
+
+- el prototipo usa antiguedad por `mtime` para considerar un lock stale
+- relee el lock antes de borrarlo para reducir falsos positivos
+- si el filesystem ofrece resolucion pobre de timestamps o semantica rara en un share remoto, el riesgo no desaparece por completo
+- metadata invalida no rompe el flujo; si el lock ya es stale, el helper puede limpiarlo usando el snapshot observado
+
+## Limite de bloqueo del event loop
+
+- el helper usa `Atomics.wait(...)` como espera bloqueante entre reintentos
+- durante esa espera, el event loop del proceso queda bloqueado
+- eso solo es aceptable aqui porque el prototipo opera sobre stores locales pequenos y callbacks cortos
+- no debe usarse para operaciones largas ni para rutas con alta contencion
+- los timeouts deben mantenerse cortos para que el bloqueo sea acotado
 
 ## Primer store candidato
 

--- a/docs/codex/file-store-locking-design.md
+++ b/docs/codex/file-store-locking-design.md
@@ -132,6 +132,18 @@ Contras:
 - si el filesystem ofrece resolucion pobre de timestamps o semantica rara en un share remoto, el riesgo no desaparece por completo
 - metadata invalida no rompe el flujo; si el lock ya es stale, el helper puede limpiarlo usando el snapshot observado
 
+## Riesgo especifico para callbacks largos
+
+- `withFileLock(...)` no debe usarse para callbacks largos
+- si un callback tarda mas que `staleAfterMs`, otro proceso podria interpretar el lock como stale aunque siga activo
+- eso vuelve inseguro este enfoque para operaciones de larga duracion o rutas con trabajo pesado dentro del callback
+- el prototipo solo es aceptable para callbacks cortos y sin I/O prolongado, como `bankEquivalenceStore.upsert`
+- para operaciones largas o stores mas sensibles se deberia evaluar:
+  - heartbeat o refresh del lock
+  - aumentar `staleAfterMs` con criterio operativo
+  - `proper-lockfile`
+  - o una estrategia de cola / proceso unico
+
 ## Limite de bloqueo del event loop
 
 - el helper usa `Atomics.wait(...)` como espera bloqueante entre reintentos
@@ -158,3 +170,9 @@ Motivos:
 - no resolver merges semanticos
 - no tocar produccion ni integraciones reales
 - no introducir colas distribuidas ni coordinacion entre servicios
+
+## Nota de verificacion de hidden Unicode
+
+- se escaneo explicitamente el diff del PR #83 y los archivos modificados del prototipo
+- ese scan no encontro BOM, bidi controls, zero-width chars, soft hyphen ni `U+FEFF`
+- GitHub UI puede seguir mostrando un warning generico de hidden Unicode, pero el scan reproducible del diff y de los archivos no encontro caracteres ocultos peligrosos

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -410,6 +410,7 @@ Motivo:
 - `createBackupFile(...)` usa un solo `.bak` y no tiene rotacion
 - el stale cleanup sigue siendo heuristico y depende de `mtime`
 - el lock manual sincrono puede bloquear el proceso bajo contencion
+- si un callback protegido supera `staleAfterMs`, otro proceso podria interpretar el lock como stale aunque siga activo
 - la mayoria de loaders legacy siguen haciendo silent catch
 
 ## Proxima fase recomendada

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -183,19 +183,22 @@ Este prototipo si mejora:
 - backup previo al write
 - errores explicitos de parseo JSON
 - formato JSON estable con newline final
+- locking local para serializar `upsert` en `bankEquivalenceStore`
 
 Este prototipo no resuelve todavia:
 
-- `lost updates` por concurrencia `read-modify-write`
+- `lost updates` en los stores que siguen legacy
 - locking entre procesos
 - retencion historica de backups
 - recuperacion automatica de JSON corrupto
 - migracion de todos los stores
+- concurrencia distribuida fuera del filesystem compartido del laboratorio
 
 En otras palabras:
 
 - reduce el riesgo de truncado y de overwrite sin respaldo inmediato
-- no elimina el problema de dos procesos leyendo el mismo estado viejo y escribiendo despues
+- reduce el riesgo de `lost updates` solo en el store piloto protegido
+- no elimina el problema de dos procesos leyendo el mismo estado viejo y escribiendo despues en los stores no migrados
 
 ### Tests agregados
 
@@ -237,6 +240,7 @@ Cambio aplicado:
   - `createBackupFile(...)`
   - `writeJsonFileAtomic(...)`
 - resolucion del path movida a `resolveOverrideStorePath()` por llamada
+- `upsert` protegido por `withFileLock(...)` para cubrir todo el ciclo `read-modify-write`
 
 Motivo de seleccion:
 
@@ -277,18 +281,32 @@ Lo que implica:
 
 ## Estrategia de locking
 
-No implementar en esta rama todavia.
+Estado actual:
 
-Orden recomendado:
+- se implemento un prototipo de locking local en `backend/src/infrastructure/storage/fileStoreLock.ts`
+- el helper usa `${filePath}.lock` y `fs.openSync(..., 'wx')`
+- el lock guarda metadata minima con `pid` y timestamp
+- el cleanup ocurre en `finally`
+- si encuentra un lock stale por edad, intenta limpiarlo antes de reintentar
+
+Lo que aun no hace:
+
+- no introduce un lock global para todos los stores
+- no resuelve coordinacion distribuida fuera del filesystem del laboratorio
+- no ofrece observabilidad ni metricas de contencion
+- no rota ni audita locks stale mas alla de su remocion basica
+
+Orden recomendado despues de este prototipo:
 
 1. atomic write
 2. backup
-3. metricas/log de conflictos
-4. locking si aun hace falta
+3. locking puntual en stores piloto
+4. metricas/log de conflictos
+5. evaluar dependencia externa si aun hace falta
 
 Motivo:
 
-- meter locks primero complica recovery y portabilidad Docker/NAS
+- este orden deja el lock como capa incremental y auditable, no como refactor global
 
 ## Proxima fase recomendada: locking real
 
@@ -335,8 +353,8 @@ Contras:
 
 Recomendacion actual:
 
-- si el siguiente experimento sigue en el repo publico laboratorio, la mejor opcion para evaluar primero es `proper-lockfile`
-- si la compatibilidad Docker/NAS genera dudas, hacer un spike pequeno comparando `proper-lockfile` vs lock manual antes de migrar stores adicionales
+- despues de este prototipo, el lock manual ya sirve para validar el patron en laboratorio
+- si aparecen problemas de stale lock, permisos o comportamiento en NAS/Docker, el siguiente spike deberia comparar `proper-lockfile` vs lock manual antes de migrar stores adicionales
 
 ## Validaciones y tests recomendados
 
@@ -344,10 +362,20 @@ Recomendacion actual:
 - sobrescribir archivo existente y confirmar backup
 - simular JSON invalido y verificar error contextual
 - simular doble write secuencial y verificar integridad
+- verificar timeout de lock y limpieza de `.lock`
+- verificar recuperacion ante stale lock
 - backend build
 - `npm test`
 - `git diff --check`
 - `python tools/check-text-encoding.py`
+
+## Limitacion actual de tests de concurrencia del store
+
+- el helper de lock si tiene cobertura directa de exclusividad, timeout y cleanup
+- `bankEquivalenceStore` tiene cobertura de integracion para stale lock y persistencia final
+- no se agrego todavia un test determinista de `upserts` concurrentes multi-proceso sobre el store
+- se pospuso porque el API actual es sincrono y una prueba con timing artificial seria mas fragil que util en esta fase
+- la siguiente iteracion puede introducir un harness de procesos controlado si hace falta validar contencion real del store
 
 ## Stores pendientes prioritarios
 
@@ -375,20 +403,20 @@ Motivo:
 
 ## Riesgos restantes
 
-- no hay locking real todavia
+- solo `bankEquivalenceStore` usa locking
 - los demas stores siguen con read/modify/write legacy
 - `createBackupFile(...)` usa un solo `.bak` y no tiene rotacion
-- no hay pruebas de concurrencia
+- no hay prueba multi-proceso determinista sobre el store piloto
 - la mayoria de loaders legacy siguen haciendo silent catch
 
 ## Proxima fase recomendada
 
-1. decidir si conviene introducir locking real con `proper-lockfile` o alternativa minima
-2. agregar pruebas de concurrencia sobre temp dirs
-3. definir retencion de backups `.bak`
-4. migrar stores de riesgo bajo-medio de forma gradual
-5. definir estrategia de recuperacion para JSON corrupto
-6. evaluar si algun store necesita writer asincrono o cola dedicada
+1. validar el prototipo de locking en el laboratorio NAS/Docker
+2. decidir si conviene mantener lock manual o evaluar `proper-lockfile`
+3. agregar un harness de concurrencia multi-proceso para el store piloto
+4. definir retencion de backups `.bak`
+5. migrar stores de riesgo bajo-medio de forma gradual
+6. definir estrategia de recuperacion para JSON corrupto
 
 ## Validacion Docker aislada
 

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -263,6 +263,7 @@ Alcance deliberadamente limitado:
 - el path se resuelve en cada `load` y `persist` con `resolveOverrideStorePath()`
 - esto mantiene el comportamiento por defecto, pero hace viable probar el store con `BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH` temporal
 - no se cambio el nombre del archivo real ni su ubicacion por defecto
+- el `upsert` del store piloto ahora queda protegido por un lock local durante todo el ciclo `read-modify-write`
 
 ## Estrategia de backup
 
@@ -285,9 +286,10 @@ Estado actual:
 
 - se implemento un prototipo de locking local en `backend/src/infrastructure/storage/fileStoreLock.ts`
 - el helper usa `${filePath}.lock` y `fs.openSync(..., 'wx')`
-- el lock guarda metadata minima con `pid` y timestamp
+- el lock guarda metadata minima con `lockId`, `pid`, `filePath` y timestamp
+- el release valida ownership por `lockId` antes de borrar
 - el cleanup ocurre en `finally`
-- si encuentra un lock stale por edad, intenta limpiarlo antes de reintentar
+- si encuentra un lock stale por edad, relee el snapshot antes de intentar limpiarlo
 
 Lo que aun no hace:
 
@@ -295,6 +297,7 @@ Lo que aun no hace:
 - no resuelve coordinacion distribuida fuera del filesystem del laboratorio
 - no ofrece observabilidad ni metricas de contencion
 - no rota ni audita locks stale mas alla de su remocion basica
+- no evita bloqueo del event loop mientras espera el lock
 
 Orden recomendado despues de este prototipo:
 
@@ -373,9 +376,8 @@ Recomendacion actual:
 
 - el helper de lock si tiene cobertura directa de exclusividad, timeout y cleanup
 - `bankEquivalenceStore` tiene cobertura de integracion para stale lock y persistencia final
-- no se agrego todavia un test determinista de `upserts` concurrentes multi-proceso sobre el store
-- se pospuso porque el API actual es sincrono y una prueba con timing artificial seria mas fragil que util en esta fase
-- la siguiente iteracion puede introducir un harness de procesos controlado si hace falta validar contencion real del store
+- ahora tambien hay un test multi-proceso que lanza varios workers Node sobre el mismo archivo temporal y verifica que no se pierdan registros
+- ese test cubre el caso objetivo del prototipo, pero sigue siendo un smoke test de laboratorio, no una prueba exhaustiva de todos los stores ni de todos los filesystems
 
 ## Stores pendientes prioritarios
 
@@ -406,14 +408,15 @@ Motivo:
 - solo `bankEquivalenceStore` usa locking
 - los demas stores siguen con read/modify/write legacy
 - `createBackupFile(...)` usa un solo `.bak` y no tiene rotacion
-- no hay prueba multi-proceso determinista sobre el store piloto
+- el stale cleanup sigue siendo heuristico y depende de `mtime`
+- el lock manual sincrono puede bloquear el proceso bajo contencion
 - la mayoria de loaders legacy siguen haciendo silent catch
 
 ## Proxima fase recomendada
 
 1. validar el prototipo de locking en el laboratorio NAS/Docker
 2. decidir si conviene mantener lock manual o evaluar `proper-lockfile`
-3. agregar un harness de concurrencia multi-proceso para el store piloto
+3. observar si el test multi-proceso y el laboratorio NAS detectan problemas de stale lock o permisos
 4. definir retencion de backups `.bak`
 5. migrar stores de riesgo bajo-medio de forma gradual
 6. definir estrategia de recuperacion para JSON corrupto

--- a/tests/bank-equivalence-store.test.mjs
+++ b/tests/bank-equivalence-store.test.mjs
@@ -124,3 +124,24 @@ test('loadBankEquivalenceOverrides throws an explicit error when the JSON file i
     })
   })
 })
+
+test('upsertBankEquivalenceOverride recovers from a stale lock file and cleans it up', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+    const lockPath = `${filePath}.lock`
+    const staleTimestamp = new Date(Date.now() - 60_000)
+
+    fs.writeFileSync(lockPath, '{"pid":999}\n', 'utf8')
+    fs.utimesSync(lockPath, staleTimestamp, staleTimestamp)
+
+    withEquivalenceStorePath(filePath, () => {
+      const stored = upsertBankEquivalenceOverride(createOverrideInput())
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+
+      assert.equal(parsed.items.length, 1)
+      assert.equal(parsed.items[0].normalizedCounterpartyName, 'ACME SA DE CV')
+      assert.equal(stored.normalizedCounterpartyName, 'ACME SA DE CV')
+      assert.equal(fs.existsSync(lockPath), false)
+    })
+  })
+})

--- a/tests/bank-equivalence-store.test.mjs
+++ b/tests/bank-equivalence-store.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -8,6 +9,8 @@ import {
   loadBankEquivalenceOverrides,
   upsertBankEquivalenceOverride,
 } from '../backend/dist/bankEquivalenceStore.js'
+
+const MULTI_PROCESS_WORKER_PATH = path.join(process.cwd(), 'tests', 'fixtures', 'bank-equivalence-upsert-worker.mjs')
 
 function withTempDirectory(callback) {
   const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bank-equivalence-store-'))
@@ -48,6 +51,35 @@ function createOverrideInput(overrides = {}) {
     creditAccount: '1150',
     ...overrides,
   }
+}
+
+function runUpsertWorker(filePath, payload) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [MULTI_PROCESS_WORKER_PATH, JSON.stringify(payload)], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH: filePath,
+      },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+
+    let stderr = ''
+
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+
+    child.on('error', reject)
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(undefined)
+        return
+      }
+
+      reject(new Error(`Worker exited with code ${code}: ${stderr.trim() || 'No stderr output.'}`))
+    })
+  })
 }
 
 test('loadBankEquivalenceOverrides returns an empty array when the file does not exist', { concurrency: false }, () => {
@@ -144,4 +176,37 @@ test('upsertBankEquivalenceOverride recovers from a stale lock file and cleans i
       assert.equal(fs.existsSync(lockPath), false)
     })
   })
+})
+
+test('upsertBankEquivalenceOverride preserves all records across multi-process upserts', { concurrency: false }, async () => {
+  const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bank-equivalence-multiprocess-'))
+
+  try {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+    const payloads = Array.from({ length: 5 }, (_, index) =>
+      createOverrideInput({
+        counterpartyName: `Counterparty ${index + 1}`,
+        normalizedCounterpartyName: `COUNTERPARTY ${index + 1}`,
+        compactCounterpartyName: `COUNTERPARTY${index + 1}`,
+        selectedBankName: `BANK ${index + 1}`,
+        netsuiteName: `NETSUITE ${index + 1}`,
+      }),
+    )
+
+    await Promise.all(payloads.map((payload) => runUpsertWorker(filePath, payload)))
+
+    withEquivalenceStorePath(filePath, () => {
+      const items = loadBankEquivalenceOverrides()
+      const normalizedNames = items.map((item) => item.normalizedCounterpartyName).sort()
+
+      assert.equal(items.length, payloads.length)
+      assert.deepEqual(
+        normalizedNames,
+        payloads.map((payload) => payload.normalizedCounterpartyName).sort(),
+      )
+      assert.equal(fs.existsSync(`${filePath}.lock`), false)
+    })
+  } finally {
+    fs.rmSync(tempDirectoryPath, { recursive: true, force: true })
+  }
 })

--- a/tests/file-store-lock.test.mjs
+++ b/tests/file-store-lock.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { resolveLockPath, withFileLock } from '../backend/dist/infrastructure/storage/fileStoreLock.js'
+
+function withTempDirectory(callback) {
+  const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'file-store-lock-'))
+
+  try {
+    callback(tempDirectoryPath)
+  } finally {
+    fs.rmSync(tempDirectoryPath, { recursive: true, force: true })
+  }
+}
+
+test('withFileLock executes the callback and returns its result', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'store.json')
+    const result = withFileLock(filePath, () => 'locked')
+
+    assert.equal(result, 'locked')
+    assert.equal(fs.existsSync(resolveLockPath(filePath)), false)
+  })
+})
+
+test('withFileLock releases the lock even when the callback throws', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'store.json')
+    const lockPath = resolveLockPath(filePath)
+
+    assert.throws(() => {
+      withFileLock(filePath, () => {
+        throw new Error('boom')
+      })
+    }, /boom/)
+
+    assert.equal(fs.existsSync(lockPath), false)
+  })
+})
+
+test('withFileLock prevents a second lock on the same file while the first lock is active', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'store.json')
+    const lockPath = resolveLockPath(filePath)
+
+    withFileLock(filePath, () => {
+      assert.equal(fs.existsSync(lockPath), true)
+      assert.throws(
+        () =>
+          withFileLock(
+            filePath,
+            () => 'nested',
+            {
+              retryDelayMs: 5,
+              timeoutMs: 40,
+              staleAfterMs: 10_000,
+            },
+          ),
+        /Timed out acquiring file lock/,
+      )
+    })
+
+    assert.equal(fs.existsSync(lockPath), false)
+  })
+})
+
+test('withFileLock allows separate locks for different files', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const firstFilePath = path.join(tempDirectoryPath, 'first.json')
+    const secondFilePath = path.join(tempDirectoryPath, 'second.json')
+
+    const result = withFileLock(firstFilePath, () =>
+      withFileLock(secondFilePath, () => `${path.basename(firstFilePath)}:${path.basename(secondFilePath)}`),
+    )
+
+    assert.equal(result, 'first.json:second.json')
+    assert.equal(fs.existsSync(resolveLockPath(firstFilePath)), false)
+    assert.equal(fs.existsSync(resolveLockPath(secondFilePath)), false)
+  })
+})
+
+test('withFileLock removes a stale lock file before entering the callback', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'store.json')
+    const lockPath = resolveLockPath(filePath)
+    const staleTimestamp = new Date(Date.now() - 60_000)
+
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true })
+    fs.writeFileSync(lockPath, '{"pid":999}\n', 'utf8')
+    fs.utimesSync(lockPath, staleTimestamp, staleTimestamp)
+
+    const result = withFileLock(
+      filePath,
+      () => {
+        assert.equal(fs.existsSync(lockPath), true)
+        return 'recovered'
+      },
+      {
+        retryDelayMs: 5,
+        timeoutMs: 100,
+        staleAfterMs: 50,
+      },
+    )
+
+    assert.equal(result, 'recovered')
+    assert.equal(fs.existsSync(lockPath), false)
+  })
+})

--- a/tests/file-store-lock.test.mjs
+++ b/tests/file-store-lock.test.mjs
@@ -109,3 +109,55 @@ test('withFileLock removes a stale lock file before entering the callback', () =
     assert.equal(fs.existsSync(lockPath), false)
   })
 })
+
+test('withFileLock does not remove a lock file replaced by another owner before release', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'store.json')
+    const lockPath = resolveLockPath(filePath)
+
+    assert.throws(
+      () =>
+        withFileLock(filePath, () => {
+          fs.rmSync(lockPath)
+          fs.writeFileSync(
+            lockPath,
+            `${JSON.stringify({
+              lockId: 'different-owner',
+              pid: 999,
+              filePath,
+              createdAtUtc: new Date().toISOString(),
+            })}\n`,
+            'utf8',
+          )
+        }),
+      /ownership mismatch/,
+    )
+
+    assert.equal(fs.existsSync(lockPath), true)
+    assert.equal(JSON.parse(fs.readFileSync(lockPath, 'utf8')).lockId, 'different-owner')
+  })
+})
+
+test('withFileLock tolerates stale lock files with unexpected metadata', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'store.json')
+    const lockPath = resolveLockPath(filePath)
+    const staleTimestamp = new Date(Date.now() - 60_000)
+
+    fs.writeFileSync(lockPath, 'not-json\n', 'utf8')
+    fs.utimesSync(lockPath, staleTimestamp, staleTimestamp)
+
+    const result = withFileLock(
+      filePath,
+      () => 'recovered-unexpected-metadata',
+      {
+        retryDelayMs: 5,
+        timeoutMs: 100,
+        staleAfterMs: 50,
+      },
+    )
+
+    assert.equal(result, 'recovered-unexpected-metadata')
+    assert.equal(fs.existsSync(lockPath), false)
+  })
+})

--- a/tests/fixtures/bank-equivalence-upsert-worker.mjs
+++ b/tests/fixtures/bank-equivalence-upsert-worker.mjs
@@ -1,0 +1,15 @@
+import { upsertBankEquivalenceOverride } from '../../backend/dist/bankEquivalenceStore.js'
+
+const serializedPayload = process.argv[2]
+
+if (typeof serializedPayload !== 'string' || serializedPayload.length === 0) {
+  console.error('Missing upsert payload argument.')
+  process.exit(1)
+}
+
+try {
+  upsertBankEquivalenceOverride(JSON.parse(serializedPayload))
+} catch (error) {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error))
+  process.exit(1)
+}

--- a/tools/check-text-encoding.py
+++ b/tools/check-text-encoding.py
@@ -10,6 +10,8 @@ PATTERNS = (
     "backend/src/**/*.ts",
     "frontend/src/**/*.ts",
     "frontend/src/**/*.tsx",
+    "docs/codex/**/*.md",
+    "tests/**/*.mjs",
     ".editorconfig",
     ".gitattributes",
     ".github/workflows/*.yml",


### PR DESCRIPTION
## Objetivo

Agregar prototipo de locking para evitar lost updates en el primer JSON store migrado.

## Cambios incluidos

- diseno de locking del lock manual para file stores
- helper `withFileLock(...)` con metadata, ownership check y timeout corto
- cobertura de tests del helper de lock
- `bankEquivalenceStore` protegido en todo el ciclo `read-modify-write`
- test multi-proceso sobre el store piloto
- roadmap actualizado del prototipo y sus limites

## Correcciones posteriores a revision

- se amplio `tools/check-text-encoding.py` para cubrir `docs/codex/**/*.md` y `tests/**/*.mjs`
- se verifico explicitamente el diff del PR y los archivos modificados contra BOM, bidi controls, zero-width chars, soft hyphen y `U+FEFF`
- el lock ahora guarda `lockId` y valida ownership antes de liberar el `.lock`
- el cleanup de stale locks relee el snapshot antes de borrar para bajar el riesgo de borrar un lock recien reemplazado
- se agrego un test observable para confirmar que `releaseLock` no borra un lock ajeno
- se agrego un test multi-proceso con workers Node sobre `bankEquivalenceStore`
- se reforzo la documentacion sobre callbacks largos y el riesgo de superar `staleAfterMs`
- se documento que el helper es sincrono y usa espera bloqueante con `Atomics.wait(...)`

## Validaciones

- `npm --prefix backend run build`: OK
- `npm --prefix frontend run build`: OK
- `npm test`: OK
- `git diff --check`: OK
- `python tools/check-text-encoding.py`: OK
- GitHub Actions `build-and-lint`: OK
- Docker isolated test: Not run

## Verificacion de hidden Unicode

- GitHub puede seguir mostrando warning en UI, pero el scan explicito del diff del PR y archivos modificados no encontro BOM, bidi controls, zero-width chars, soft hyphen ni `U+FEFF`.

## Riesgos restantes

- solo `bankEquivalenceStore` usa locking por ahora
- los demas stores siguen con `read-modify-write` legacy
- el stale cleanup sigue siendo heuristico y depende de `mtime`
- el lock manual es sincrono y puede bloquear el event loop bajo contencion
- si un callback protegido supera `staleAfterMs`, otro proceso podria interpretar el lock como stale aunque siga activo
- no hay compare-and-delete atomico del `.lock` a nivel filesystem

## Que NO se toco

- `main`
- repo privado
- produccion
- secretos
- integraciones reales
- otros stores fuera del piloto
- `proper-lockfile`

## Recomendacion

Mantener este PR como draft. El prototipo ya es mas auditable y cubre el caso multi-proceso del store piloto, pero sigue siendo laboratorio tecnico y no deberia extenderse a mas stores sin observar primero su comportamiento en NAS/Docker y revisar si el lock manual escala.
