### PR TITLE
docs: add file store locking architecture decision

### DIFF
--- a/docs/codex/file-store-locking-decision.md
+++ b/docs/codex/file-store-locking-decision.md
@@ -1,0 +1,216 @@
+# File Store Locking Decision
+
+## Objetivo
+
+Definir una decision tecnica clara para el siguiente paso de persistencia local despues del prototipo de locking de `PR #83`, sin expandir todavia el patron a mas stores.
+
+## Insumos revisados
+
+- `backend/src/infrastructure/storage/fileStoreLock.ts` en `codex/file-store-locking-prototype`
+- `backend/src/bankEquivalenceStore.ts` en `codex/file-store-locking-prototype`
+- `tests/file-store-lock.test.mjs`
+- `tests/bank-equivalence-store.test.mjs`
+- `docs/codex/file-store-locking-design.md`
+- `docs/codex/file-store-reliability-plan.md`
+- stores locales listados en `backend/src`
+
+## Resumen ejecutivo
+
+La decision recomendada no es elegir una sola opcion para todos los stores.
+
+Recomendacion por capas:
+
+1. no expandir el lock manual actual como patron general
+2. mantener `PR #83` como experimento acotado y util para aprendizaje
+3. si se quiere seguir endureciendo JSON stores de riesgo bajo o medio, evaluar `proper-lockfile` antes de migrar mas stores
+4. para stores criticos, write-heavy o con valor de auditoria, empezar a planear migracion a SQLite o un almacenamiento local con transacciones
+5. mantener algunos stores legacy temporalmente cuando su concurrencia sea baja y el costo de migracion hoy no se justifique
+
+## Comparacion de opciones
+
+| Opcion | Que problema resuelve | Riesgos | Complejidad | Impacto en NAS/Docker | Impacto en Windows/Linux | Impacto en CI | Riesgo de bloquear event loop | Riesgo de stale lock | Riesgo de lost updates | Facilidad de testeo | Facilidad de revertir |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| A) Mantener lock manual actual | serializa `read-modify-write` en un store puntual sin dependencias nuevas | ownership no atomico, stale lock heuristico, mantenimiento manual | baja-media | bueno para laboratorio si el filesystem respeta `open('wx')` y `rename`; requiere validacion real en montajes NAS | bueno en teoria, pero hay que vigilar semantica de archivos y permisos | baja friccion; solo corre tests Node actuales | alto, porque usa `Atomics.wait(...)` y espera bloqueante | medio | bajo en el store protegido, alto en los demas | alta para casos basicos; media para edge cases multi-proceso | alta |
+| B) Usar `proper-lockfile` | mejora manejo de lockfile, retries y stale lock sin reimplementar tanta logica | dependencia nueva, aun depende del filesystem, configuracion incorrecta puede dar falsa seguridad | media | mejor que el lock manual para uso extendido si valida bien en NAS | razonable, pero hay que probar diferencias entre Windows y Linux | media; hay que agregar instalacion y tests de libreria | bajo-medio si se usa version async; menor que el lock manual bloqueante | medio-bajo | bajo para stores protegidos | media-alta | media |
+| C) Usar SQLite / local DB para stores criticos | reduce `lost updates` con transacciones reales, mejora consistencia y consultas | migracion mayor, schema/versionado, nueva capa operativa | alta | muy bueno si el contenedor escribe a volumen local estable; mas robusto que muchos JSON sueltos | bueno y conocido; SQLite funciona bien en Windows y Linux | media; hay que agregar tests/inicializacion, pero sigue siendo local | bajo | muy bajo | muy bajo | media | media-baja |
+| D) Usar proceso unico / queue para writes intensivos | serializa escrituras dentro de una instancia y reduce colisiones en flujos write-heavy | no protege multiples procesos o multiples contenedores por si solo | media | util si realmente hay una sola instancia escritora; limitado si el NAS levanta mas de una | poco dependiente del SO; mas dependiente del modelo de despliegue | media; requiere harness especifico | bajo-medio | nulo si no usa lockfile; depende de la cola | medio si hay mas de un proceso | media | media |
+| E) Mantener algunos stores legacy temporalmente | evita tocar stores de baja concurrencia o alta sensibilidad mientras se disena mejor | deja deuda tecnica y riesgo residual | baja | sin impacto inmediato | sin impacto inmediato | sin impacto inmediato | nulo | nulo | medio o alto segun store | alta, porque no cambia nada | muy alta |
+
+## Analisis por opcion
+
+### A) Mantener lock manual actual
+
+Conviene solo como experimento de laboratorio y como referencia de diseño.
+
+Fortalezas:
+
+- ya existe
+- no agrega dependencias
+- ya cubre ownership basico, stale cleanup heuristico y test multi-proceso del store piloto
+
+Limites:
+
+- usa espera bloqueante con `Atomics.wait(...)`
+- la seguridad del release sigue dependiendo de pasos separados de lectura y borrado
+- stale cleanup se basa en `mtime`, no en heartbeat ni lease real
+
+Decision:
+
+- no recomendarlo como patron general para todos los stores
+- si se conserva, que sea solo para aprender y para comparar contra la siguiente opcion
+
+### B) Usar `proper-lockfile`
+
+Es la mejor opcion incremental si se quiere seguir con JSON stores un tiempo mas.
+
+Fortalezas:
+
+- reduce logica artesanal de locking
+- permite avanzar store por store sin migrar de golpe a otra tecnologia
+- baja el riesgo de bugs propios del lock manual
+
+Limites:
+
+- no elimina todos los riesgos del filesystem compartido
+- sigue siendo lockfile sobre archivos JSON
+- requiere validar bien tiempos, stale behavior y semantica en NAS
+
+Decision:
+
+- mejor siguiente paso incremental para stores JSON de riesgo bajo o medio
+- no implementarlo todavia en esta rama
+
+### C) Usar SQLite / local DB
+
+Es la mejor opcion de fondo para stores criticos, de auditoria o con muchas escrituras.
+
+Fortalezas:
+
+- transacciones
+- consistencia mucho mas fuerte
+- menos fragilidad que coordinar muchos JSON con lockfiles
+
+Limites:
+
+- migracion mayor
+- cambia operacion y testing
+- no es una mejora pequena como las fases anteriores
+
+Decision:
+
+- recomendar como direccion futura para stores criticos
+- no usarlo como siguiente experimento pequeno
+
+### D) Usar proceso unico / queue
+
+Sirve como complemento, no como solucion universal.
+
+Fortalezas:
+
+- bueno para flujos con muchas escrituras y trabajo secuencial
+- evita bloquear por lockfiles dentro del mismo proceso
+
+Limites:
+
+- no resuelve el problema entre procesos o contenedores
+- depende de supuestos de despliegue mas que de la persistencia en si
+
+Decision:
+
+- reservarlo para flujos write-heavy y casos donde una sola instancia escritora sea realista
+- no usarlo como solucion primaria para todos los stores locales
+
+### E) Mantener stores legacy temporalmente
+
+Es razonable para caches y snapshots con baja concurrencia.
+
+Fortalezas:
+
+- evita tocar stores donde el retorno inmediato es bajo
+- concentra el esfuerzo en los stores que si tienen riesgo real
+
+Limites:
+
+- no resuelve deuda tecnica
+- deja `lost updates` y silent catches donde ya existen
+
+Decision:
+
+- si, pero de forma explicitamente temporal y priorizada
+
+## Clasificacion de stores locales
+
+### Stores principales
+
+| Archivo | Tipo de datos | Read-modify-write | Puede tener concurrencia | Datos sensibles | Prioridad para locking | Recomendacion |
+| --- | --- | --- | --- | --- | --- | --- |
+| `backend/src/bankEquivalenceStore.ts` | equivalencias manuales de contrapartes | si | media | no alta | ya piloto | mantener como referencia del prototipo; no expandir mas en esta rama |
+| `backend/src/bankRecognitionOverrideStore.ts` | overrides manuales de reconocimiento bancario | si | media-alta | media | alta | no usar lock manual directamente; evaluar `proper-lockfile` o esperar una fase mas madura |
+| `backend/src/bankBalanceValidationStore.ts` | saldos validados por archivo/hash/corte | si | media | baja-media | media-alta | mejor siguiente store piloto si se sigue con JSON + locking |
+| `backend/src/bankHistoricalRegistryStore.ts` | corroboraciones y resumen historico bancario | si | media-alta | media | alta | postergar a una opcion mas robusta; mejor `proper-lockfile` o DB |
+| `backend/src/bankIndividualPaymentStore.ts` | archivos de pagos individuales con base64 | si | media | media-alta | media | no usar como siguiente piloto; volumen y base64 lo vuelven peor candidato |
+| `backend/src/bankWorkingFileStore.ts` | archivo bancario de trabajo con base64 | si | alta | media-alta | alta | evitar piloto con lock manual; mejor atomicidad fuerte o almacenamiento mas robusto |
+| `backend/src/banxicoCepRecognitionStore.ts` | reconocimientos manuales CEP | si | media | media | media | posible candidato futuro despues de validar mejor la estrategia |
+| `backend/src/claveSatStore.ts` | snapshot de catalogo SAT | si, pero mas tipo snapshot/cache | baja | baja | baja | puede quedarse legacy o migrar solo a atomic write; no urge locking |
+| `backend/src/egresosConciliationStore.ts` | conciliaciones locales de egresos | si | media | media | media-alta | buen candidato secundario despues de `bankBalanceValidationStore` |
+| `backend/src/kontempoStore.ts` | homologaciones, recognitions e import runs de Kontempo | si | alta | media | alta | demasiado grande para siguiente piloto; pensar en DB o estrategia dedicada |
+| `backend/src/netsuiteAccountStore.ts` | cache catalogo de cuentas NetSuite | si, pero snapshot/cache | baja | baja-media | baja | mantener legacy temporalmente; priorizar atomic write antes que locking |
+| `backend/src/netsuiteEntityStore.ts` | cache catalogos NetSuite | si, pero snapshot/cache | baja | baja-media | baja | mantener legacy temporalmente; no necesita siguiente piloto |
+| `backend/src/satDownloadHistoryStore.ts` | historial de descargas SAT y CFDI | si | alta | alta | muy alta | mejor candidato a SQLite o almacenamiento transaccional, no a otro piloto pequeno |
+| `backend/src/satIgnoredCfdiStore.ts` | archivo de CFDI ignorados | si | media | media-alta | media-alta | no piloto inmediato; considerar despues con estrategia mas estable |
+| `backend/src/satManualHomologationStore.ts` | homologaciones manuales SAT | si | media-alta | alta | alta | no piloto pequeno; mejor cuando exista decision mas robusta |
+| `backend/src/satRetentionAccountStore.ts` | reglas de cuentas de retenciones SAT | si | media-baja | media | media | puede esperar; correctness importante pero write frequency menor |
+
+### Persistencias auxiliares relacionadas
+
+| Archivo | Tipo de datos | Read-modify-write | Puede tener concurrencia | Datos sensibles | Prioridad para locking | Recomendacion |
+| --- | --- | --- | --- | --- | --- | --- |
+| `backend/src/bankAnalysisRunStore.ts` | corridas de analisis bancario y resultados | si | alta | media | muy alta | no seguir con lock manual; pensar en DB local o estrategia de proceso/cola |
+| `backend/src/netsuiteOAuth.ts` | sesion OAuth y tokens | si | baja-media | muy alta | no por locking | priorizar token vault / cifrado, no locking |
+| `backend/src/satAnalysisWindows.ts` | estado de workflow SAT | si | alta | alta | muy alta | candidato claro para DB o modelo mas robusto que JSON + lockfile |
+| `backend/src/inventoryLotReplacementRegistry.ts` | registry de reemplazos de lote | si | media | baja-media | media | tecnicamente pequeno, pero mejor mantener foco en bancos para el siguiente piloto |
+
+## Siguiente store piloto sugerido
+
+Recomendacion principal:
+
+- `backend/src/bankBalanceValidationStore.ts`
+
+Por que:
+
+- sigue el mismo patron `read-modify-write` que ya se endurecio en `bankEquivalenceStore`
+- es pequeno y acotado
+- no guarda secretos ni blobs base64
+- tiene claves de negocio claras (`bankId`, `sourceFileHash`, `cutoffDate`)
+- es facil de testear con archivos temporales
+- pertenece al mismo dominio de bancos, lo que reduce cambio de contexto respecto al prototipo anterior
+
+Segunda opcion si se quisiera un siguiente paso fuera de bancos:
+
+- `backend/src/egresosConciliationStore.ts`
+
+Por que no recomiendo otros como siguiente piloto:
+
+- `bankRecognitionOverrideStore.ts`: mas impacto de negocio y matching mas delicado
+- `bankWorkingFileStore.ts` y `bankIndividualPaymentStore.ts`: base64 y volumen de datos
+- `sat*` y `bankAnalysisRunStore.ts`: mejor pensar ya en una estrategia mas fuerte que lock manual
+
+## Recomendacion de arquitectura
+
+Recomendacion final:
+
+1. mantener `PR #83` como prototipo y no tomar el lock manual como estandar final
+2. si el equipo quiere una mejora incremental sobre JSON, el siguiente spike deberia comparar el lock manual contra `proper-lockfile`
+3. si esa comparacion sale bien, aplicar la opcion elegida a `bankBalanceValidationStore.ts`
+4. en paralelo, planear una ruta distinta para stores criticos:
+   - `bankAnalysisRunStore.ts`
+   - `satDownloadHistoryStore.ts`
+   - `satAnalysisWindows.ts`
+   - `kontempoStore.ts`
+5. para esos stores criticos, la direccion recomendada es SQLite o un almacenamiento local con transacciones, no una proliferacion de lockfiles manuales
+
+## Que no se recomienda hacer ahora
+
+- no expandir el lock manual actual a muchos stores sin una comparacion contra `proper-lockfile`
+- no migrar stores sensibles de SAT u OAuth con el mismo patron experimental
+- no asumir que el prototipo de `PR #83` ya es suficiente para produccion o para todos los filesystems

--- a/docs/codex/file-store-locking-decision.md
+++ b/docs/codex/file-store-locking-decision.md
@@ -1,216 +1,355 @@
 # File Store Locking Decision
 
-## Objetivo
+## Estado
 
-Definir una decision tecnica clara para el siguiente paso de persistencia local despues del prototipo de locking de `PR #83`, sin expandir todavia el patron a mas stores.
+Draft decision para laboratorio.
 
-## Insumos revisados
+Recomendacion tecnica posterior al prototipo de `PR #83`.
 
-- `backend/src/infrastructure/storage/fileStoreLock.ts` en `codex/file-store-locking-prototype`
-- `backend/src/bankEquivalenceStore.ts` en `codex/file-store-locking-prototype`
-- `tests/file-store-lock.test.mjs`
-- `tests/bank-equivalence-store.test.mjs`
-- `docs/codex/file-store-locking-design.md`
-- `docs/codex/file-store-reliability-plan.md`
-- stores locales listados en `backend/src`
+## Fecha
 
-## Resumen ejecutivo
+2026-04-27
 
-La decision recomendada no es elegir una sola opcion para todos los stores.
+## Contexto
 
-Recomendacion por capas:
+`PR #83` probo un lock manual sobre `backend/src/bankEquivalenceStore.ts` para cubrir un caso real de `read-modify-write` concurrente.
+
+Ese prototipo fue util para validar varias cosas:
+
+- un `lockId` propio por adquisicion
+- validacion de ownership antes de liberar el `.lock`
+- stale cleanup con doble snapshot
+- cobertura basica del helper de lock
+- smoke test multi-proceso para el store piloto
+
+Tambien dejo claros sus limites:
+
+- espera bloqueante con `Atomics.wait(...)`
+- stale cleanup heuristico basado en `mtime`
+- riesgo de event loop blocking bajo contencion
+- no es una base suficiente para expandir el patron a todos los stores sin una decision previa
+
+Por eso este documento no implementa una tecnologia nueva. Solo fija la recomendacion para el siguiente paso.
+
+## Decision
+
+La recomendacion es hibrida:
 
 1. no expandir el lock manual actual como patron general
-2. mantener `PR #83` como experimento acotado y util para aprendizaje
-3. si se quiere seguir endureciendo JSON stores de riesgo bajo o medio, evaluar `proper-lockfile` antes de migrar mas stores
-4. para stores criticos, write-heavy o con valor de auditoria, empezar a planear migracion a SQLite o un almacenamiento local con transacciones
-5. mantener algunos stores legacy temporalmente cuando su concurrencia sea baja y el costo de migracion hoy no se justifique
+2. evaluar `proper-lockfile` para JSON stores de riesgo bajo o medio
+3. planear SQLite o local DB para stores criticos o write-heavy
+4. mantener algunos stores legacy temporalmente cuando su concurrencia sea baja y el costo de migracion hoy no se justifique
 
-## Comparacion de opciones
-
-| Opcion | Que problema resuelve | Riesgos | Complejidad | Impacto en NAS/Docker | Impacto en Windows/Linux | Impacto en CI | Riesgo de bloquear event loop | Riesgo de stale lock | Riesgo de lost updates | Facilidad de testeo | Facilidad de revertir |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| A) Mantener lock manual actual | serializa `read-modify-write` en un store puntual sin dependencias nuevas | ownership no atomico, stale lock heuristico, mantenimiento manual | baja-media | bueno para laboratorio si el filesystem respeta `open('wx')` y `rename`; requiere validacion real en montajes NAS | bueno en teoria, pero hay que vigilar semantica de archivos y permisos | baja friccion; solo corre tests Node actuales | alto, porque usa `Atomics.wait(...)` y espera bloqueante | medio | bajo en el store protegido, alto en los demas | alta para casos basicos; media para edge cases multi-proceso | alta |
-| B) Usar `proper-lockfile` | mejora manejo de lockfile, retries y stale lock sin reimplementar tanta logica | dependencia nueva, aun depende del filesystem, configuracion incorrecta puede dar falsa seguridad | media | mejor que el lock manual para uso extendido si valida bien en NAS | razonable, pero hay que probar diferencias entre Windows y Linux | media; hay que agregar instalacion y tests de libreria | bajo-medio si se usa version async; menor que el lock manual bloqueante | medio-bajo | bajo para stores protegidos | media-alta | media |
-| C) Usar SQLite / local DB para stores criticos | reduce `lost updates` con transacciones reales, mejora consistencia y consultas | migracion mayor, schema/versionado, nueva capa operativa | alta | muy bueno si el contenedor escribe a volumen local estable; mas robusto que muchos JSON sueltos | bueno y conocido; SQLite funciona bien en Windows y Linux | media; hay que agregar tests/inicializacion, pero sigue siendo local | bajo | muy bajo | muy bajo | media | media-baja |
-| D) Usar proceso unico / queue para writes intensivos | serializa escrituras dentro de una instancia y reduce colisiones en flujos write-heavy | no protege multiples procesos o multiples contenedores por si solo | media | util si realmente hay una sola instancia escritora; limitado si el NAS levanta mas de una | poco dependiente del SO; mas dependiente del modelo de despliegue | media; requiere harness especifico | bajo-medio | nulo si no usa lockfile; depende de la cola | medio si hay mas de un proceso | media | media |
-| E) Mantener algunos stores legacy temporalmente | evita tocar stores de baja concurrencia o alta sensibilidad mientras se disena mejor | deja deuda tecnica y riesgo residual | baja | sin impacto inmediato | sin impacto inmediato | sin impacto inmediato | nulo | nulo | medio o alto segun store | alta, porque no cambia nada | muy alta |
-
-## Analisis por opcion
+## Opciones consideradas
 
 ### A) Mantener lock manual actual
 
-Conviene solo como experimento de laboratorio y como referencia de diseño.
+Que problema resuelve:
 
-Fortalezas:
+- serializa `read-modify-write` en un store puntual sin dependencias nuevas
 
-- ya existe
-- no agrega dependencias
-- ya cubre ownership basico, stale cleanup heuristico y test multi-proceso del store piloto
+Riesgos:
 
-Limites:
+- ownership no atomico
+- stale lock heuristico
+- logica artesanal de mantenimiento
 
-- usa espera bloqueante con `Atomics.wait(...)`
-- la seguridad del release sigue dependiendo de pasos separados de lectura y borrado
-- stale cleanup se basa en `mtime`, no en heartbeat ni lease real
+Complejidad:
 
-Decision:
+- baja a media
 
-- no recomendarlo como patron general para todos los stores
-- si se conserva, que sea solo para aprender y para comparar contra la siguiente opcion
+Impacto en NAS/Docker:
+
+- util para laboratorio si el filesystem respeta `open('wx')` y `rename`
+- requiere validacion real en montajes NAS
+
+Impacto en Windows/Linux:
+
+- teoricamente portable, pero sensible a permisos y semantica de archivos
+
+Impacto en CI:
+
+- bajo; usa el test runner actual
+
+Riesgo de bloquear event loop:
+
+- alto por `Atomics.wait(...)`
+
+Riesgo de stale lock:
+
+- medio
+
+Riesgo de lost updates:
+
+- bajo en el store protegido
+- alto en los stores no migrados
+
+Que tan facil es testearlo:
+
+- alto para casos basicos
+- medio para edge cases multi-proceso
+
+Que tan facil es revertirlo:
+
+- alto
 
 ### B) Usar `proper-lockfile`
 
-Es la mejor opcion incremental si se quiere seguir con JSON stores un tiempo mas.
+Que problema resuelve:
 
-Fortalezas:
+- mejora manejo de lockfile, retries y stale lock sin reimplementar tanta logica propia
 
-- reduce logica artesanal de locking
-- permite avanzar store por store sin migrar de golpe a otra tecnologia
-- baja el riesgo de bugs propios del lock manual
+Riesgos:
 
-Limites:
+- dependencia nueva
+- falsa sensacion de seguridad si no se valida en NAS/Docker
 
-- no elimina todos los riesgos del filesystem compartido
-- sigue siendo lockfile sobre archivos JSON
-- requiere validar bien tiempos, stale behavior y semantica en NAS
+Complejidad:
 
-Decision:
+- media
 
-- mejor siguiente paso incremental para stores JSON de riesgo bajo o medio
-- no implementarlo todavia en esta rama
+Impacto en NAS/Docker:
 
-### C) Usar SQLite / local DB
+- potencialmente mejor que el lock manual, pero depende de validacion real sobre el montaje
 
-Es la mejor opcion de fondo para stores criticos, de auditoria o con muchas escrituras.
+Impacto en Windows/Linux:
 
-Fortalezas:
+- razonable, con menos logica casera que mantener
 
-- transacciones
-- consistencia mucho mas fuerte
-- menos fragilidad que coordinar muchos JSON con lockfiles
+Impacto en CI:
 
-Limites:
+- medio; hay que instalar y cubrir la dependencia
+
+Riesgo de bloquear event loop:
+
+- menor que el lock manual si se usa flujo async
+
+Riesgo de stale lock:
+
+- medio a bajo, segun configuracion y pruebas reales
+
+Riesgo de lost updates:
+
+- bajo para los stores protegidos
+
+Que tan facil es testearlo:
+
+- medio a alto
+
+Que tan facil es revertirlo:
+
+- medio
+
+### C) Usar SQLite / local DB para stores criticos
+
+Que problema resuelve:
+
+- reduce `lost updates` con transacciones reales
+- mejora consistencia, trazabilidad y consultas
+
+Riesgos:
 
 - migracion mayor
-- cambia operacion y testing
-- no es una mejora pequena como las fases anteriores
+- schema y versionado
+- nueva capa operativa
 
-Decision:
+Complejidad:
 
-- recomendar como direccion futura para stores criticos
-- no usarlo como siguiente experimento pequeno
+- alta
 
-### D) Usar proceso unico / queue
+Impacto en NAS/Docker:
 
-Sirve como complemento, no como solucion universal.
+- bueno si el volumen local esta bien definido
+- mas robusto que muchos JSON con lockfiles
 
-Fortalezas:
+Impacto en Windows/Linux:
 
-- bueno para flujos con muchas escrituras y trabajo secuencial
-- evita bloquear por lockfiles dentro del mismo proceso
+- bueno y conocido
 
-Limites:
+Impacto en CI:
 
-- no resuelve el problema entre procesos o contenedores
-- depende de supuestos de despliegue mas que de la persistencia en si
+- medio; necesita inicializacion y tests de persistencia
 
-Decision:
+Riesgo de bloquear event loop:
 
-- reservarlo para flujos write-heavy y casos donde una sola instancia escritora sea realista
-- no usarlo como solucion primaria para todos los stores locales
+- bajo
 
-### E) Mantener stores legacy temporalmente
+Riesgo de stale lock:
 
-Es razonable para caches y snapshots con baja concurrencia.
+- muy bajo
 
-Fortalezas:
+Riesgo de lost updates:
 
-- evita tocar stores donde el retorno inmediato es bajo
-- concentra el esfuerzo en los stores que si tienen riesgo real
+- muy bajo
 
-Limites:
+Que tan facil es testearlo:
 
-- no resuelve deuda tecnica
-- deja `lost updates` y silent catches donde ya existen
+- medio
 
-Decision:
+Que tan facil es revertirlo:
 
-- si, pero de forma explicitamente temporal y priorizada
+- medio a bajo
 
-## Clasificacion de stores locales
+### D) Usar proceso unico / queue para operaciones write-heavy
+
+Que problema resuelve:
+
+- serializa escrituras dentro de una instancia
+- reduce colisiones en flujos con muchas escrituras
+
+Riesgos:
+
+- no protege multiples procesos o multiples contenedores por si solo
+
+Complejidad:
+
+- media
+
+Impacto en NAS/Docker:
+
+- util solo si el despliegue realmente tiene una sola instancia escritora
+
+Impacto en Windows/Linux:
+
+- bajo impacto por SO; alto impacto por modelo de despliegue
+
+Impacto en CI:
+
+- medio; requiere harness especifico
+
+Riesgo de bloquear event loop:
+
+- bajo a medio
+
+Riesgo de stale lock:
+
+- nulo si no usa lockfile
+
+Riesgo de lost updates:
+
+- medio si hay mas de un proceso o contenedor
+
+Que tan facil es testearlo:
+
+- medio
+
+Que tan facil es revertirlo:
+
+- medio
+
+### E) Mantener algunos stores legacy temporalmente
+
+Que problema resuelve:
+
+- evita tocar stores de baja concurrencia o alta sensibilidad mientras se disena mejor la estrategia
+
+Riesgos:
+
+- deja deuda tecnica
+- mantiene riesgo residual de `lost updates`
+
+Complejidad:
+
+- baja
+
+Impacto en NAS/Docker:
+
+- nulo inmediato
+
+Impacto en Windows/Linux:
+
+- nulo inmediato
+
+Impacto en CI:
+
+- nulo inmediato
+
+Riesgo de bloquear event loop:
+
+- nulo
+
+Riesgo de stale lock:
+
+- nulo
+
+Riesgo de lost updates:
+
+- medio o alto segun store
+
+Que tan facil es testearlo:
+
+- alto, porque no cambia nada
+
+Que tan facil es revertirlo:
+
+- muy alto
+
+## Consecuencias
+
+Esta decision habilita:
+
+- una ruta incremental para stores JSON de riesgo bajo o medio
+- una ruta distinta para stores criticos, sin forzar un lock manual donde no conviene
+- una priorizacion explicita de stores antes de tocar mas codigo
+
+Esta decision no resuelve todavia:
+
+- el comportamiento real de `proper-lockfile` en NAS/Docker
+- la migracion de stores criticos a SQLite
+- la deuda actual de stores legacy
+- el problema de produccion para todos los filesystems posibles
+
+## Clasificacion actual de stores
 
 ### Stores principales
 
-| Archivo | Tipo de datos | Read-modify-write | Puede tener concurrencia | Datos sensibles | Prioridad para locking | Recomendacion |
+| Archivo | Tipo de datos | Read-modify-write | Puede tener concurrencia | Toca datos sensibles | Prioridad para locking | Recomendacion |
 | --- | --- | --- | --- | --- | --- | --- |
-| `backend/src/bankEquivalenceStore.ts` | equivalencias manuales de contrapartes | si | media | no alta | ya piloto | mantener como referencia del prototipo; no expandir mas en esta rama |
-| `backend/src/bankRecognitionOverrideStore.ts` | overrides manuales de reconocimiento bancario | si | media-alta | media | alta | no usar lock manual directamente; evaluar `proper-lockfile` o esperar una fase mas madura |
-| `backend/src/bankBalanceValidationStore.ts` | saldos validados por archivo/hash/corte | si | media | baja-media | media-alta | mejor siguiente store piloto si se sigue con JSON + locking |
-| `backend/src/bankHistoricalRegistryStore.ts` | corroboraciones y resumen historico bancario | si | media-alta | media | alta | postergar a una opcion mas robusta; mejor `proper-lockfile` o DB |
-| `backend/src/bankIndividualPaymentStore.ts` | archivos de pagos individuales con base64 | si | media | media-alta | media | no usar como siguiente piloto; volumen y base64 lo vuelven peor candidato |
-| `backend/src/bankWorkingFileStore.ts` | archivo bancario de trabajo con base64 | si | alta | media-alta | alta | evitar piloto con lock manual; mejor atomicidad fuerte o almacenamiento mas robusto |
-| `backend/src/banxicoCepRecognitionStore.ts` | reconocimientos manuales CEP | si | media | media | media | posible candidato futuro despues de validar mejor la estrategia |
-| `backend/src/claveSatStore.ts` | snapshot de catalogo SAT | si, pero mas tipo snapshot/cache | baja | baja | baja | puede quedarse legacy o migrar solo a atomic write; no urge locking |
-| `backend/src/egresosConciliationStore.ts` | conciliaciones locales de egresos | si | media | media | media-alta | buen candidato secundario despues de `bankBalanceValidationStore` |
-| `backend/src/kontempoStore.ts` | homologaciones, recognitions e import runs de Kontempo | si | alta | media | alta | demasiado grande para siguiente piloto; pensar en DB o estrategia dedicada |
-| `backend/src/netsuiteAccountStore.ts` | cache catalogo de cuentas NetSuite | si, pero snapshot/cache | baja | baja-media | baja | mantener legacy temporalmente; priorizar atomic write antes que locking |
-| `backend/src/netsuiteEntityStore.ts` | cache catalogos NetSuite | si, pero snapshot/cache | baja | baja-media | baja | mantener legacy temporalmente; no necesita siguiente piloto |
-| `backend/src/satDownloadHistoryStore.ts` | historial de descargas SAT y CFDI | si | alta | alta | muy alta | mejor candidato a SQLite o almacenamiento transaccional, no a otro piloto pequeno |
-| `backend/src/satIgnoredCfdiStore.ts` | archivo de CFDI ignorados | si | media | media-alta | media-alta | no piloto inmediato; considerar despues con estrategia mas estable |
-| `backend/src/satManualHomologationStore.ts` | homologaciones manuales SAT | si | media-alta | alta | alta | no piloto pequeno; mejor cuando exista decision mas robusta |
-| `backend/src/satRetentionAccountStore.ts` | reglas de cuentas de retenciones SAT | si | media-baja | media | media | puede esperar; correctness importante pero write frequency menor |
+| `backend/src/bankEquivalenceStore.ts` | equivalencias manuales de contrapartes | si | media | no alta | ya piloto | mantener como referencia del prototipo |
+| `backend/src/bankRecognitionOverrideStore.ts` | overrides manuales de reconocimiento bancario | si | media-alta | media | alta | no usar lock manual directo; evaluar `proper-lockfile` o una fase mas madura |
+| `backend/src/bankBalanceValidationStore.ts` | saldos validados por archivo/hash/corte | si | media | baja-media | media-alta | mejor candidato para un piloto posterior |
+| `backend/src/bankHistoricalRegistryStore.ts` | corroboraciones y resumen historico bancario | si | media-alta | media | alta | postergar a una opcion mas robusta |
+| `backend/src/bankIndividualPaymentStore.ts` | pagos individuales con base64 | si | media | media-alta | media | no usar como siguiente piloto |
+| `backend/src/bankWorkingFileStore.ts` | archivo bancario de trabajo con base64 | si | alta | media-alta | alta | evitar piloto con lock manual |
+| `backend/src/banxicoCepRecognitionStore.ts` | reconocimientos manuales CEP | si | media | media | media | posible candidato futuro, no inmediato |
+| `backend/src/claveSatStore.ts` | snapshot de catalogo SAT | si, mas tipo cache | baja | baja | baja | puede quedarse legacy temporalmente |
+| `backend/src/egresosConciliationStore.ts` | conciliaciones locales de egresos | si | media | media | media-alta | buen candidato secundario |
+| `backend/src/kontempoStore.ts` | homologaciones, recognitions e import runs | si | alta | media | alta | demasiado grande para siguiente piloto |
+| `backend/src/netsuiteAccountStore.ts` | cache de cuentas NetSuite | si, mas tipo cache | baja | baja-media | baja | mantener legacy temporalmente |
+| `backend/src/netsuiteEntityStore.ts` | cache de entidades NetSuite | si, mas tipo cache | baja | baja-media | baja | mantener legacy temporalmente |
+| `backend/src/satDownloadHistoryStore.ts` | historial SAT y CFDI | si | alta | alta | muy alta | mejor candidato a SQLite, no a otro piloto pequeno |
+| `backend/src/satIgnoredCfdiStore.ts` | archivo de CFDI ignorados | si | media | media-alta | media-alta | no piloto inmediato |
+| `backend/src/satManualHomologationStore.ts` | homologaciones manuales SAT | si | media-alta | alta | alta | no piloto pequeno |
+| `backend/src/satRetentionAccountStore.ts` | reglas de cuentas de retenciones SAT | si | media-baja | media | media | puede esperar |
 
 ### Persistencias auxiliares relacionadas
 
-| Archivo | Tipo de datos | Read-modify-write | Puede tener concurrencia | Datos sensibles | Prioridad para locking | Recomendacion |
+| Archivo | Tipo de datos | Read-modify-write | Puede tener concurrencia | Toca datos sensibles | Prioridad para locking | Recomendacion |
 | --- | --- | --- | --- | --- | --- | --- |
-| `backend/src/bankAnalysisRunStore.ts` | corridas de analisis bancario y resultados | si | alta | media | muy alta | no seguir con lock manual; pensar en DB local o estrategia de proceso/cola |
-| `backend/src/netsuiteOAuth.ts` | sesion OAuth y tokens | si | baja-media | muy alta | no por locking | priorizar token vault / cifrado, no locking |
-| `backend/src/satAnalysisWindows.ts` | estado de workflow SAT | si | alta | alta | muy alta | candidato claro para DB o modelo mas robusto que JSON + lockfile |
-| `backend/src/inventoryLotReplacementRegistry.ts` | registry de reemplazos de lote | si | media | baja-media | media | tecnicamente pequeno, pero mejor mantener foco en bancos para el siguiente piloto |
+| `backend/src/bankAnalysisRunStore.ts` | corridas de analisis bancario y resultados | si | alta | media | muy alta | pensar en DB local o proceso/cola, no en otro lock manual |
+| `backend/src/netsuiteOAuth.ts` | sesion OAuth y tokens | si | baja-media | muy alta | no por locking | priorizar cifrado o token vault |
+| `backend/src/satAnalysisWindows.ts` | estado de workflow SAT | si | alta | alta | muy alta | candidato a DB o modelo mas robusto |
+| `backend/src/inventoryLotReplacementRegistry.ts` | registry de reemplazos de lote | si | media | baja-media | media | pequeno, pero fuera del foco actual |
 
-## Siguiente store piloto sugerido
+## Siguiente experimento recomendado
 
-Recomendacion principal:
+1. no migrar mas stores todavia
+2. crear un PR separado para comparar lock manual vs `proper-lockfile`
+3. usar `backend/src/bankBalanceValidationStore.ts` como candidato de analisis o piloto posterior
+4. solo aplicar la estrategia al store si el spike demuestra que es segura en temp dirs, CI y entorno similar a NAS/Docker
 
-- `backend/src/bankBalanceValidationStore.ts`
+## Fuera de alcance
 
-Por que:
+- no implementacion en esta rama
+- no `proper-lockfile` todavia
+- no SQLite todavia
+- no migracion de stores
+- no cambios en produccion
+- no validacion contra NAS real
+- no cambios en el repo privado
 
-- sigue el mismo patron `read-modify-write` que ya se endurecio en `bankEquivalenceStore`
-- es pequeno y acotado
-- no guarda secretos ni blobs base64
-- tiene claves de negocio claras (`bankId`, `sourceFileHash`, `cutoffDate`)
-- es facil de testear con archivos temporales
-- pertenece al mismo dominio de bancos, lo que reduce cambio de contexto respecto al prototipo anterior
+## Verificacion de hidden Unicode
 
-Segunda opcion si se quisiera un siguiente paso fuera de bancos:
-
-- `backend/src/egresosConciliationStore.ts`
-
-Por que no recomiendo otros como siguiente piloto:
-
-- `bankRecognitionOverrideStore.ts`: mas impacto de negocio y matching mas delicado
-- `bankWorkingFileStore.ts` y `bankIndividualPaymentStore.ts`: base64 y volumen de datos
-- `sat*` y `bankAnalysisRunStore.ts`: mejor pensar ya en una estrategia mas fuerte que lock manual
-
-## Recomendacion de arquitectura
-
-Recomendacion final:
-
-1. mantener `PR #83` como prototipo y no tomar el lock manual como estandar final
-2. si el equipo quiere una mejora incremental sobre JSON, el siguiente spike deberia comparar el lock manual contra `proper-lockfile`
-3. si esa comparacion sale bien, aplicar la opcion elegida a `bankBalanceValidationStore.ts`
-4. en paralelo, planear una ruta distinta para stores criticos:
-   - `bankAnalysisRunStore.ts`
-   - `satDownloadHistoryStore.ts`
-   - `satAnalysisWindows.ts`
-   - `kontempoStore.ts`
-5. para esos stores criticos, la direccion recomendada es SQLite o un almacenamiento local con transacciones, no una proliferacion de lockfiles manuales
-
-## Que no se recomienda hacer ahora
-
-- no expandir el lock manual actual a muchos stores sin una comparacion contra `proper-lockfile`
-- no migrar stores sensibles de SAT u OAuth con el mismo patron experimental
-- no asumir que el prototipo de `PR #83` ya es suficiente para produccion o para todos los filesystems
+- se escaneo explicitamente el diff del PR y los archivos modificados
+- ese scan no encontro BOM, bidi controls, zero-width chars, soft hyphen ni `U+FEFF`
+- GitHub UI puede seguir mostrando warning generico, pero el scan reproducible del diff y de los archivos no encontro caracteres ocultos peligrosos

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -290,6 +290,43 @@ Motivo:
 
 - meter locks primero complica recovery y portabilidad Docker/NAS
 
+## Recomendacion de locking
+
+Decision actual:
+
+- no tomar el lock manual de `PR #83` como patron general todavia
+- si se quiere seguir endureciendo JSON stores de riesgo bajo o medio, el siguiente paso recomendado es evaluar `proper-lockfile`
+- para stores criticos o write-heavy, la direccion recomendada ya no es multiplicar lockfiles sino empezar a planear SQLite o un almacenamiento local con transacciones
+
+Siguiente store piloto sugerido:
+
+- `backend/src/bankBalanceValidationStore.ts`
+
+Motivos:
+
+- pequeno
+- sin secretos ni base64
+- `read-modify-write` claro
+- mismo dominio de bancos que el piloto anterior
+- facil de testear con archivos temporales
+
+Stores que no conviene usar como siguiente piloto:
+
+- `bankWorkingFileStore.ts`
+- `bankIndividualPaymentStore.ts`
+- `bankAnalysisRunStore.ts`
+- `satDownloadHistoryStore.ts`
+- `satManualHomologationStore.ts`
+- `netsuiteOAuth.ts`
+
+Motivo:
+
+- son mas sensibles, mas voluminosos o piden una estrategia mas robusta que JSON + lock manual
+
+Documento relacionado:
+
+- `docs/codex/file-store-locking-decision.md`
+
 ## Proxima fase recomendada: locking real
 
 Opciones razonables para la siguiente fase:

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -302,6 +302,12 @@ Siguiente store piloto sugerido:
 
 - `backend/src/bankBalanceValidationStore.ts`
 
+Importante:
+
+- se mantiene solo como candidato de analisis o piloto posterior
+- este documento no recomienda migrarlo todavia
+- antes debe existir un spike separado que compare lock manual vs `proper-lockfile`
+
 Motivos:
 
 - pequeno
@@ -326,6 +332,14 @@ Motivo:
 Documento relacionado:
 
 - `docs/codex/file-store-locking-decision.md`
+
+## Proximo PR recomendado
+
+- crear un spike separado para comparar lock manual vs `proper-lockfile`
+- no migrar `bankBalanceValidationStore.ts` todavia
+- no agregar SQLite todavia
+- validar el spike solo con temp dirs, CI y pruebas documentadas
+- documentar requisitos y riesgos para NAS/Docker antes de pensar en uso fuera del laboratorio
 
 ## Proxima fase recomendada: locking real
 

--- a/tools/check-text-encoding.py
+++ b/tools/check-text-encoding.py
@@ -10,6 +10,7 @@ PATTERNS = (
     "backend/src/**/*.ts",
     "frontend/src/**/*.ts",
     "frontend/src/**/*.tsx",
+    "docs/codex/**/*.md",
     ".editorconfig",
     ".gitattributes",
     ".github/workflows/*.yml",


### PR DESCRIPTION
## Objetivo

Documentar una decision de arquitectura clara para la estrategia de locking/persistencia local despues del prototipo de `PR #83`, sin expandir todavia el patron a mas stores.

## Cambios incluidos

- el documento principal se reestructuro como architecture decision record
- se compararon lock manual, `proper-lockfile`, SQLite/local DB, proceso unico/queue y mantener stores legacy temporalmente
- se clasificaron los stores locales principales y auxiliares por riesgo y recomendacion
- se dejo recomendacion hibrida de arquitectura
- se actualizo el roadmap base de confiabilidad con recomendacion de locking y siguiente spike sugerido
- se amplio `tools/check-text-encoding.py` para cubrir `docs/codex/**/*.md`

## Decision recomendada

- no expandir el lock manual actual como patron general
- evaluar `proper-lockfile` para JSON stores de riesgo bajo o medio
- planear SQLite o local DB para stores criticos o write-heavy
- mantener algunos stores legacy temporalmente cuando su concurrencia sea baja y el costo de migracion hoy no se justifique

## Siguiente PR recomendado

- crear spike separado para comparar lock manual vs `proper-lockfile`
- no migrar `bankBalanceValidationStore.ts` todavia
- no usar `proper-lockfile` en produccion sin validar NAS/Docker
- no tocar stores criticos como SAT, OAuth, `bankAnalysisRunStore` o stores con base64

## Validaciones

- `npm --prefix backend run build`: OK
- `npm --prefix frontend run build`: OK
- `npm test`: OK
- `git diff --check`: OK
- `python tools/check-text-encoding.py`: OK
- Docker isolated test: Not run

## Verificacion de hidden Unicode

- GitHub puede seguir mostrando warning en UI, pero el scan explicito del diff del PR y archivos modificados no encontro BOM, bidi controls, zero-width chars, soft hyphen ni `U+FEFF`.

## Que NO se toco

- `main`
- repo privado
- produccion
- secretos
- integraciones reales
- backend funcional
- frontend
- `proper-lockfile`
- SQLite
- migracion de stores

## Riesgos restantes

- esta rama solo documenta una decision; no valida todavia `proper-lockfile` ni SQLite en runtime real
- los stores legacy siguen igual hasta una siguiente rama de implementacion
- el prototipo de `PR #83` sigue siendo laboratorio tecnico y no una decision final de produccion

## Recomendacion

Mantener este PR como draft. Usarlo como decision de arquitectura para elegir el siguiente spike, no como implementacion de locking adicional.
