### PR TITLE
refactor: port file store reliability utilities

### DIFF
--- a/backend/src/bankEquivalenceStore.ts
+++ b/backend/src/bankEquivalenceStore.ts
@@ -1,6 +1,10 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
+import {
+  createBackupFile,
+  readJsonFile,
+  writeJsonFileAtomic,
+} from './infrastructure/storage/fileStoreUtils.js'
 import type { BankImportBankId, BankImportMappingSheet } from './types.js'
 
 type MappingSheetKey = BankImportMappingSheet['key']
@@ -24,28 +28,19 @@ type StoredBankEquivalenceOverrideFile = {
   items: StoredBankEquivalenceOverride[]
 }
 
-const OVERRIDE_STORE_PATH =
-  process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH?.trim() ||
-  path.join(process.env.LOCALAPPDATA || process.cwd(), 'netsuite-recon', 'bank-equivalence-overrides.json')
-
 export function loadBankEquivalenceOverrides() {
-  if (!fs.existsSync(OVERRIDE_STORE_PATH)) {
+  const parsed = readJsonFile<Partial<StoredBankEquivalenceOverrideFile>>(resolveOverrideStorePath(), {
+    version: 2,
+    items: [],
+  })
+
+  if (!Array.isArray(parsed.items)) {
     return []
   }
 
-  try {
-    const raw = fs.readFileSync(OVERRIDE_STORE_PATH, 'utf8')
-    const parsed = JSON.parse(raw) as Partial<StoredBankEquivalenceOverrideFile>
-    if (!Array.isArray(parsed.items)) {
-      return []
-    }
-
-    return parsed.items
-      .map(normalizeStoredOverride)
-      .filter((item): item is StoredBankEquivalenceOverride => item !== null)
-  } catch {
-    return []
-  }
+  return parsed.items
+    .map(normalizeStoredOverride)
+    .filter((item): item is StoredBankEquivalenceOverride => item !== null)
 }
 
 export function upsertBankEquivalenceOverride(
@@ -77,15 +72,14 @@ export function upsertBankEquivalenceOverride(
 }
 
 function persistOverrides(items: StoredBankEquivalenceOverride[]) {
-  const directoryPath = path.dirname(OVERRIDE_STORE_PATH)
-  fs.mkdirSync(directoryPath, { recursive: true })
-
   const payload: StoredBankEquivalenceOverrideFile = {
     version: 2,
     items,
   }
+  const storePath = resolveOverrideStorePath()
 
-  fs.writeFileSync(OVERRIDE_STORE_PATH, JSON.stringify(payload, null, 2), 'utf8')
+  createBackupFile(storePath)
+  writeJsonFileAtomic(storePath, payload)
 }
 
 function isStoredOverride(value: unknown): value is StoredBankEquivalenceOverride {
@@ -153,4 +147,11 @@ function resolveLegacySourceProfileId(bankId: BankImportBankId, mappingSheetKey:
   }
 
   return 'payana_transacciones'
+}
+
+function resolveOverrideStorePath() {
+  return (
+    process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH?.trim() ||
+    path.join(process.env.LOCALAPPDATA || process.cwd(), 'netsuite-recon', 'bank-equivalence-overrides.json')
+  )
 }

--- a/backend/src/infrastructure/storage/fileStoreUtils.ts
+++ b/backend/src/infrastructure/storage/fileStoreUtils.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+type JsonFallback<T> = T | (() => T)
+
+export function readJsonFile<T>(filePath: string, fallback: JsonFallback<T>) {
+  if (!fs.existsSync(filePath)) {
+    return resolveFallback(fallback)
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8').replace(/^\uFEFF/u, '')
+
+  try {
+    return JSON.parse(raw) as T
+  } catch (error) {
+    throw new Error(
+      `Failed to parse JSON file at ${filePath}: ${error instanceof Error ? error.message : 'Unknown parse error.'}`,
+    )
+  }
+}
+
+export function writeJsonFileAtomic(filePath: string, data: unknown) {
+  const directoryPath = path.dirname(filePath)
+  const temporaryPath = `${filePath}.${process.pid}.${Date.now()}.tmp`
+  const payload = safeJsonStringify(data)
+
+  fs.mkdirSync(directoryPath, { recursive: true })
+
+  try {
+    fs.writeFileSync(temporaryPath, payload, 'utf8')
+    fs.renameSync(temporaryPath, filePath)
+  } finally {
+    if (fs.existsSync(temporaryPath)) {
+      fs.rmSync(temporaryPath, { force: true })
+    }
+  }
+}
+
+export function createBackupFile(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    return null
+  }
+
+  const backupPath = `${filePath}.bak`
+  fs.copyFileSync(filePath, backupPath)
+  return backupPath
+}
+
+export function safeJsonStringify(data: unknown) {
+  const serialized = JSON.stringify(data, null, 2)
+
+  if (typeof serialized !== 'string') {
+    throw new Error('Unable to serialize JSON payload for file store persistence.')
+  }
+
+  return `${serialized}\n`
+}
+
+function resolveFallback<T>(fallback: JsonFallback<T>) {
+  return typeof fallback === 'function' ? (fallback as () => T)() : fallback
+}

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -62,6 +62,9 @@ Comportamiento:
   - serializa con formato consistente y newline final
   - escribe primero a `*.tmp`
   - usa `rename` para reemplazo atomico
+  - reduce el riesgo de escrituras parciales al evitar sobrescribir el archivo final directamente
+  - no garantiza durabilidad total ante corte electrico o crash del sistema porque no hace `fsync` ni del archivo temporal ni del directorio
+  - para este port inicial es aceptable, pero si el patron se mueve a stores criticos habra que evaluar `fsync` y requisitos de durabilidad mas adelante
 - `createBackupFile(...)`
   - crea un `.bak` del archivo existente antes de sobrescribir
   - no falla si el archivo aun no existe

--- a/docs/codex/file-store-reliability-plan.md
+++ b/docs/codex/file-store-reliability-plan.md
@@ -1,0 +1,147 @@
+# File Store Reliability Plan
+
+## Objetivo
+
+Crear una base pequena y revisable para mejorar la persistencia local en stores JSON sin migrar todo el sistema ni introducir locking todavia.
+
+## Alcance de este PR
+
+Este port solo trae la parte util del prototipo original:
+
+- `backend/src/infrastructure/storage/fileStoreUtils.ts`
+- migracion puntual de `backend/src/bankEquivalenceStore.ts`
+- `tests/file-store-utils.test.mjs`
+- `tests/bank-equivalence-store.test.mjs`
+
+Queda fuera de alcance:
+
+- locking manual o con dependencia externa
+- migracion de mas stores
+- cambios a `package.json`
+- cambios al runner de tests
+- cambios de API, deploy o integraciones reales
+
+## Problema que se quiere reducir
+
+El patron actual de muchos stores JSON es:
+
+1. leer archivo
+2. parsear JSON
+3. modificar en memoria
+4. reescribir el archivo completo
+
+Eso deja varios riesgos:
+
+- escrituras parciales si el proceso cae durante el write
+- ausencia de backup inmediato
+- parse errors ocultos por `catch { return [] }`
+- read/modify/write repetido sin helper compartido
+
+Este PR solo ataca la parte de atomicidad basica, backup inmediato y errores de parseo explicitos.
+
+## Utilidades nuevas
+
+Archivo:
+
+- `backend/src/infrastructure/storage/fileStoreUtils.ts`
+
+Funciones:
+
+- `readJsonFile(...)`
+- `writeJsonFileAtomic(...)`
+- `createBackupFile(...)`
+- `safeJsonStringify(...)`
+
+Comportamiento:
+
+- `readJsonFile(...)`
+  - devuelve fallback si el archivo no existe
+  - limpia BOM UTF-8 al leer
+  - lanza error explicito con path si el JSON esta corrupto
+- `writeJsonFileAtomic(...)`
+  - serializa con formato consistente y newline final
+  - escribe primero a `*.tmp`
+  - usa `rename` para reemplazo atomico
+- `createBackupFile(...)`
+  - crea un `.bak` del archivo existente antes de sobrescribir
+  - no falla si el archivo aun no existe
+
+## Store migrado en este PR
+
+Archivo:
+
+- `backend/src/bankEquivalenceStore.ts`
+
+Cambios aplicados:
+
+- la lectura manual se reemplaza por `readJsonFile(...)`
+- la escritura directa se reemplaza por:
+  - `createBackupFile(...)`
+  - `writeJsonFileAtomic(...)`
+- el path del store se resuelve por llamada con `resolveOverrideStorePath()`
+
+## Cambio de comportamiento importante
+
+Antes de este port, `loadBankEquivalenceOverrides()` hacia silent catch si el JSON estaba corrupto y devolvia `[]`.
+
+Con este port:
+
+- si el archivo no existe, sigue devolviendo `[]`
+- si el JSON esta corrupto, ahora lanza un error explicito con el path del archivo
+
+Este cambio es intencional porque evita ocultar corrupcion real del store, pero si cambia el comportamiento previo ante archivos danados.
+
+## Compatibilidad y riesgo
+
+Compatibilidad mantenida:
+
+- no cambia el shape de datos
+- no cambia el nombre del archivo
+- no cambia la ubicacion por defecto
+- no cambia contratos API
+
+Riesgo introducido:
+
+- un archivo corrupto deja de degradar silenciosamente a `[]` y pasa a fallar explicitamente
+
+Ese riesgo es aceptable para este port porque hace visible un problema de datos que antes quedaba oculto, pero debe revisarse antes de extender el patron a stores mas sensibles.
+
+## Tests incluidos
+
+### `tests/file-store-utils.test.mjs`
+
+Cubre:
+
+- fallback cuando el archivo no existe
+- lectura de JSON valido
+- error explicito con JSON invalido
+- write atomico con newline final
+- reemplazo de contenido existente
+- creacion de `.bak`
+- no fallo cuando no existe archivo original
+
+### `tests/bank-equivalence-store.test.mjs`
+
+Cubre:
+
+- `loadBankEquivalenceOverrides()` devuelve `[]` si no existe archivo
+- `upsertBankEquivalenceOverride(...)` crea archivo `version: 2`
+- segundo upsert del mismo item no duplica registros
+- se crea `.bak` al sobrescribir
+- un JSON corrupto lanza error explicito
+
+## Lo que este PR no resuelve todavia
+
+- `lost updates` por concurrencia `read-modify-write`
+- locking entre procesos
+- retencion historica de backups
+- recuperacion automatica de JSON corrupto
+- migracion del resto de stores JSON
+
+## Siguiente paso recomendado
+
+Si este port resulta util y estable en `main`, el siguiente paso deberia ser un PR separado para:
+
+1. evaluar otro store pequeno y no sensible
+2. decidir si hace falta locking
+3. definir si el comportamiento de error explicito ante JSON corrupto debe mantenerse igual en todos los stores o adaptarse por dominio

--- a/tests/architecture-docs.test.mjs
+++ b/tests/architecture-docs.test.mjs
@@ -13,7 +13,7 @@ const requiredDocs = [
   '../docs/codex/token-vault-design.md',
 ]
 
-test('architecture roadmap docs exist and keep file-store work out of this PR', async () => {
+test('architecture roadmap docs exist and still describe file-store work as a separate track', async () => {
   for (const relativePath of requiredDocs) {
     await access(new URL(relativePath, import.meta.url))
   }
@@ -27,7 +27,5 @@ test('architecture roadmap docs exist and keep file-store work out of this PR', 
   assert.match(triageSource, /tratarlo en una rama y PR separados/)
   assert.match(triageSource, /#85.*CI \+ encoding guardrails/s)
 
-  await assert.rejects(
-    access(new URL('../docs/codex/file-store-reliability-plan.md', import.meta.url)),
-  )
+  await access(new URL('../docs/codex/file-store-reliability-plan.md', import.meta.url))
 })

--- a/tests/bank-equivalence-store.test.mjs
+++ b/tests/bank-equivalence-store.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  loadBankEquivalenceOverrides,
+  upsertBankEquivalenceOverride,
+} from '../backend/dist/bankEquivalenceStore.js'
+
+function withTempDirectory(callback) {
+  const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bank-equivalence-store-'))
+
+  try {
+    callback(tempDirectoryPath)
+  } finally {
+    fs.rmSync(tempDirectoryPath, { recursive: true, force: true })
+  }
+}
+
+function withEquivalenceStorePath(filePath, callback) {
+  const previousValue = process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH
+
+  process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH = filePath
+
+  try {
+    callback()
+  } finally {
+    if (typeof previousValue === 'string') {
+      process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH = previousValue
+    } else {
+      delete process.env.BANKS_EQUIVALENCE_OVERRIDE_STORE_PATH
+    }
+  }
+}
+
+function createOverrideInput(overrides = {}) {
+  return {
+    bankId: 'bbva',
+    sourceProfileId: 'bbva_pdf',
+    mappingSheetKey: 'customers',
+    counterpartyName: 'Acme SA de CV',
+    normalizedCounterpartyName: 'ACME SA DE CV',
+    compactCounterpartyName: 'ACMESADECV',
+    selectedBankName: 'ACME SA',
+    netsuiteName: 'ACME CUSTOMER',
+    creditAccount: '1150',
+    ...overrides,
+  }
+}
+
+test('loadBankEquivalenceOverrides returns an empty array when the file does not exist', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+
+    withEquivalenceStorePath(filePath, () => {
+      assert.deepEqual(loadBankEquivalenceOverrides(), [])
+    })
+  })
+})
+
+test('upsertBankEquivalenceOverride creates a version 2 file with one item', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+
+    withEquivalenceStorePath(filePath, () => {
+      const stored = upsertBankEquivalenceOverride(createOverrideInput())
+      const rawFile = fs.readFileSync(filePath, 'utf8')
+      const parsed = JSON.parse(rawFile)
+
+      assert.equal(parsed.version, 2)
+      assert.equal(parsed.items.length, 1)
+      assert.equal(parsed.items[0].bankId, 'bbva')
+      assert.equal(typeof parsed.items[0].createdAtUtc, 'string')
+      assert.equal(typeof parsed.items[0].updatedAtUtc, 'string')
+      assert.equal(stored.createdAtUtc, parsed.items[0].createdAtUtc)
+      assert.equal(stored.updatedAtUtc, parsed.items[0].updatedAtUtc)
+    })
+  })
+})
+
+test('upsertBankEquivalenceOverride updates the same item without duplicating it and creates a backup', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+
+    withEquivalenceStorePath(filePath, () => {
+      const first = upsertBankEquivalenceOverride(createOverrideInput())
+      const second = upsertBankEquivalenceOverride(
+        createOverrideInput({
+          selectedBankName: 'ACME SA UPDATED',
+          netsuiteName: 'ACME CUSTOMER UPDATED',
+        }),
+      )
+
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      const backup = JSON.parse(fs.readFileSync(`${filePath}.bak`, 'utf8'))
+
+      assert.equal(parsed.items.length, 1)
+      assert.equal(parsed.items[0].selectedBankName, 'ACME SA UPDATED')
+      assert.equal(parsed.items[0].netsuiteName, 'ACME CUSTOMER UPDATED')
+      assert.equal(second.createdAtUtc, first.createdAtUtc)
+      assert.equal(second.updatedAtUtc >= first.updatedAtUtc, true)
+      assert.equal(fs.existsSync(`${filePath}.bak`), true)
+      assert.equal(backup.items.length, 1)
+      assert.equal(backup.items[0].selectedBankName, 'ACME SA')
+    })
+  })
+})
+
+test('loadBankEquivalenceOverrides throws an explicit error when the JSON file is corrupt', { concurrency: false }, () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'bank-equivalence-overrides.json')
+    fs.writeFileSync(filePath, '{ invalid json }\n', 'utf8')
+
+    withEquivalenceStorePath(filePath, () => {
+      assert.throws(
+        () => loadBankEquivalenceOverrides(),
+        (error) =>
+          error instanceof Error &&
+          error.message.includes('Failed to parse JSON file at') &&
+          error.message.includes(filePath),
+      )
+    })
+  })
+})

--- a/tests/file-store-utils.test.mjs
+++ b/tests/file-store-utils.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  createBackupFile,
+  readJsonFile,
+  safeJsonStringify,
+  writeJsonFileAtomic,
+} from '../backend/dist/infrastructure/storage/fileStoreUtils.js'
+
+function withTempDirectory(callback) {
+  const tempDirectoryPath = fs.mkdtempSync(path.join(os.tmpdir(), 'file-store-utils-'))
+
+  try {
+    callback(tempDirectoryPath)
+  } finally {
+    fs.rmSync(tempDirectoryPath, { recursive: true, force: true })
+  }
+}
+
+test('readJsonFile returns the fallback when the file does not exist', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'missing.json')
+
+    assert.deepEqual(readJsonFile(filePath, { items: [] }), { items: [] })
+  })
+})
+
+test('readJsonFile reads valid JSON content', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'valid.json')
+    fs.writeFileSync(filePath, '{\n  "value": 42\n}\n', 'utf8')
+
+    assert.deepEqual(readJsonFile(filePath, { value: 0 }), { value: 42 })
+  })
+})
+
+test('readJsonFile fails explicitly when the JSON is invalid', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'invalid.json')
+    fs.writeFileSync(filePath, '{ invalid json }\n', 'utf8')
+
+    assert.throws(
+      () => readJsonFile(filePath, { value: 0 }),
+      (error) =>
+        error instanceof Error &&
+        error.message.includes('Failed to parse JSON file at') &&
+        error.message.includes(filePath),
+    )
+  })
+})
+
+test('writeJsonFileAtomic creates a JSON file with a final newline', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'payload.json')
+
+    writeJsonFileAtomic(filePath, { ok: true })
+
+    const written = fs.readFileSync(filePath, 'utf8')
+    assert.equal(written, '{\n  "ok": true\n}\n')
+    assert.equal(written.endsWith('\n'), true)
+  })
+})
+
+test('writeJsonFileAtomic replaces existing content', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'payload.json')
+    fs.writeFileSync(filePath, '{\n  "old": true\n}\n', 'utf8')
+
+    writeJsonFileAtomic(filePath, { next: 'value' })
+
+    assert.deepEqual(JSON.parse(fs.readFileSync(filePath, 'utf8')), { next: 'value' })
+  })
+})
+
+test('createBackupFile creates a .bak copy when the original file exists', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'payload.json')
+    fs.writeFileSync(filePath, safeJsonStringify({ source: 'original' }), 'utf8')
+
+    const backupPath = createBackupFile(filePath)
+
+    assert.equal(backupPath, `${filePath}.bak`)
+    assert.equal(fs.existsSync(`${filePath}.bak`), true)
+    assert.deepEqual(JSON.parse(fs.readFileSync(`${filePath}.bak`, 'utf8')), { source: 'original' })
+  })
+})
+
+test('createBackupFile does not fail when the original file does not exist', () => {
+  withTempDirectory((tempDirectoryPath) => {
+    const filePath = path.join(tempDirectoryPath, 'missing.json')
+
+    assert.equal(createBackupFile(filePath), null)
+    assert.equal(fs.existsSync(`${filePath}.bak`), false)
+  })
+})


### PR DESCRIPTION
## Objetivo

Portar a main la base util del prototipo de confiabilidad de file stores sin arrastrar la rama laboratorio ni introducir locking todavia.

## Cambios incluidos

- nuevo helper ackend/src/infrastructure/storage/fileStoreUtils.ts
- migracion puntual de ackend/src/bankEquivalenceStore.ts a lectura con helper, backup inmediato y escritura atomica
- tests nuevos para ileStoreUtils
- tests nuevos para ankEquivalenceStore
- documento docs/codex/file-store-reliability-plan.md
- ajuste minimo en 	ests/architecture-docs.test.mjs para permitir que este nuevo plan conviva con la documentacion ya mergeada en main

## Validaciones

- 
pm --prefix backend run build: OK
- 
pm --prefix frontend run build: OK
- 
pm test: OK
- git diff --check: OK
- python tools/check-text-encoding.py: OK

## Riesgo principal

loadBankEquivalenceOverrides() cambia su comportamiento ante JSON corrupto: antes hacia silent catch y devolvia []; ahora lanza un error explicito con el path del archivo. El comportamiento cuando el archivo no existe se mantiene igual.

## Que no se toco

- package.json
- runner de tests
- locking de PR #83
- decision de PR #84
- contratos API
- produccion
- repo privado
