### PR TITLE
audit(001b): incluir /api/bancos/analysis/recover en LARGE_JSON_BODY_LIMIT

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -188,6 +188,7 @@ export function createApp() {
     [
       '/api/bancos/analyze',
       '/api/bancos/analysis/start',
+      '/api/bancos/analysis/recover',
       '/api/bancos/history/upload',
       '/api/bancos/pagos-individuales/upload',
     ],

--- a/deploy/nas/README.md
+++ b/deploy/nas/README.md
@@ -71,6 +71,7 @@ Todo esto queda fuera del contenedor y sobrevive reinicios:
 
 - No apuntes el contenedor a tu carpeta de trabajo viva como volumen de codigo.
 - Usa `APP_PUBLIC_BASE_URL` real para que OAuth y enlaces de retorno no queden amarrados a `127.0.0.1`.
+- Configura `ALLOWED_ORIGINS` en `netsuite-recon.env` con la URL real del NAS antes de desplegar. En produccion el backend rechaza arrancar con la lista vacia.
 - Si quieres OAuth 2.0 de NetSuite, el `redirect URI` debe ser HTTPS o un dominio/tunel valido.
 - Si solo usaras TBA, puedes dejar OAuth vacio.
 


### PR DESCRIPTION
## Resumen

Cierra el follow-up de TASK-001B (#3, #4): agrega `/api/bancos/analysis/recover` a la lista de endpoints que reciben `LARGE_JSON_BODY_LIMIT` y documenta `ALLOWED_ORIGINS` en el README de deploy NAS.

## Cambios

- `backend/src/app.ts`: añade `/api/bancos/analysis/recover` al middleware de payload grande, junto a `/analyze`, `/analysis/start`, `/history/upload` y `/pagos-individuales/upload`. Ese endpoint recibe el mismo `fileBase64` que `/analysis/start`, así que con el límite global de 1mb cualquier recuperación de análisis bancario grande fallaba.
- `deploy/nas/README.md`: agrega bullet en "Cosas a cuidar" sobre `ALLOWED_ORIGINS` en producción NAS, ya que `runtimeSecurity.ts` aborta el arranque si la lista queda vacía cuando `NODE_ENV=production` o `APP_ENV=production`.

## Validación

CI corre `npm test`, lint y build automáticamente. Cambio puramente aditivo, sin tocar lógica de bancos.

## Issues que cierra

Closes #3
Closes #4