### PR TITLE
audit(007): proteger /api/netsuite/suiteql y POST externos con requireInternalApiKey

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -395,7 +395,7 @@ export function createApp() {
     }
   })
 
-  app.post('/api/bancos/cep/lookup', async (request, response) => {
+  app.post('/api/bancos/cep/lookup', requireInternalApiKey, async (request, response) => {
     try {
       response.json(await lookupBanxicoCep(request.body))
     } catch (error) {
@@ -561,7 +561,7 @@ export function createApp() {
     }
   })
 
-  app.post('/api/catalogs/netsuite/accounts/import/preview', async (request, response) => {
+  app.post('/api/catalogs/netsuite/accounts/import/preview', requireInternalApiKey, async (request, response) => {
     try {
       response.json(await previewNetSuiteAccountImport(typeof request.body?.rawText === 'string' ? request.body.rawText : null))
     } catch (error) {
@@ -630,7 +630,7 @@ export function createApp() {
     }
   })
 
-  app.post('/api/search/transactions', async (request, response) => {
+  app.post('/api/search/transactions', requireInternalApiKey, async (request, response) => {
     try {
       const client = NetSuiteClient.fromEnv()
       response.json(await searchTransactions(client, request.body))
@@ -1511,7 +1511,7 @@ export function createApp() {
     }
   })
 
-  app.post('/api/netsuite/suiteql', async (request, response) => {
+  app.post('/api/netsuite/suiteql', requireInternalApiKey, async (request, response) => {
     try {
       const client = NetSuiteClient.fromEnv()
       const query = String(request.body.query ?? '')


### PR DESCRIPTION
## Resumen

Hallazgo crítico de la auditoría 2026-04-29: cuatro endpoints POST que disparan trabajo contra sistemas externos (NetSuite, Banxico) quedaron sin el middleware `requireInternalApiKey`, mientras que los demás POST mutadores ya estaban protegidos.

## Endpoints afectados

| Ruta | Riesgo | Consumido por frontend |
|---|---|---|
| `POST /api/netsuite/suiteql` | **Crítico** — ejecuta SuiteQL arbitrario contra NetSuite (backdoor de lectura genérica al ERP) | No (uso manual / scripts) |
| `POST /api/search/transactions` | Alto — enumera transacciones, dispara búsquedas pesadas | Sí, vía `httpClient` |
| `POST /api/bancos/cep/lookup` | Medio — abuso contra Banxico CEP, rate-limit y costo | Sí, vía `httpClient` |
| `POST /api/catalogs/netsuite/accounts/import/preview` | Medio — expone estructura del catálogo contable | Sí, vía `httpClient` |

## Cambio

Una línea por endpoint: agregar `requireInternalApiKey` como middleware antes del handler. Mismo patrón que ya se usa en los otros 28 POST mutadores de `app.ts`.

## Por qué no rompe el frontend

El `frontend/src/services/api/httpClient.ts:53-56` ya inyecta `X-Internal-Api-Key` desde `VITE_INTERNAL_API_KEY` en todas las requests. Las tres rutas consumidas por el frontend siguen funcionando. `suiteql` no es llamado desde el frontend (es endpoint para `Invoke-NetSuiteSuiteQL.ps1` y scripts).

## Validación

CI corre lint + build + tests automáticamente.

## Origen del hallazgo

Auditoría con agente Explore independiente sobre la rama main post-PRs Codex (#85–#90).